### PR TITLE
docs: autonomous implementation for issue #1 (docs: note the autonomous local runner setup)

### DIFF
--- a/docs/repo-guide.md
+++ b/docs/repo-guide.md
@@ -121,6 +121,12 @@ Example:
 /home/shimizu/study/AI/hayashi/package/app-b
 ```
 
+## Autonomous Local Runner
+
+The autonomous issue runner (`.github/workflows/autonomous-agent.yml`) executes on a self-hosted PC runner labeled `my-app-local`. The runner uses a local Claude Code login so no additional API-key configuration is needed on the runner itself.
+
+To register the runner, add the labels `self-hosted`, `linux`, `x64`, and `my-app-local` when configuring the GitHub Actions runner on your PC.
+
 ## Current Stack
 
 This repository currently uses:


### PR DESCRIPTION
## Autonomous local runner execution

**Issue**: #1
**Title**: docs: note the autonomous local runner setup
**Runner**: self-hosted local PC with Claude Code

### Verification
- OK `npm run typecheck`
- OK `npm run lint`
- OK `npm run build`

### Files changed
- `ocs/repo-guide.md`

### Claude summary
## Summary

Added a new **"Autonomous Local Runner"** section to `docs/repo-guide.md` (lines 124-128). It explains that:

- The autonomous issue workflow runs on a self-hosted runner labeled `my-app-local`.
- The runner relies on a local Claude Code login (no separate API key needed on the runner).
- How to register the runner with the correct labels.

The change is documentation-only and minimal, placed just before the existing "Current Stack" section.

## Checks

- **File modified**: `docs/repo-guide.md` — 5 lines added
- **No code changes**: documentation only
- **Consistent with workflow**: labels match `autonomous-agent.yml` (`self-hosted, linux, x64, my-app-local`)
- **No commits or branches created**: changes left in working tree as requested

Closes #1