### PR TITLE
docs: autonomous implementation for issue #1 (docs: note the autonomous local runner setup)

### DIFF
--- a/docs/repo-guide.md
+++ b/docs/repo-guide.md
@@ -121,6 +121,26 @@ Example:
 /home/shimizu/study/AI/hayashi/package/app-b
 ```
 
+## Autonomous Local Runner
+
+Issues labelled `🤖agent-execute` (or triggered via `/agent` comments) are
+processed by the `autonomous-agent.yml` workflow. The `execute-agents` job runs
+on a self-hosted PC runner with the label **`my-app-local`** (`[self-hosted,
+linux, x64, my-app-local]`).
+
+The runner relies on a **local Claude Code login** — no API key is passed
+through GitHub Actions secrets for this step. Before the pipeline executes it
+checks `claude auth status`; if the session is not authenticated the run is
+skipped and a comment is posted on the issue.
+
+To set up or restore the runner:
+
+1. Register a GitHub Actions self-hosted runner on the PC and assign the
+   `my-app-local` label.
+2. Log into Claude Code interactively on that machine (`claude login`).
+3. Start the runner service — the workflow will pick up labelled issues
+   automatically.
+
 ## Current Stack
 
 This repository currently uses:


### PR DESCRIPTION
## Autonomous local runner execution

**Issue**: #1
**Title**: docs: note the autonomous local runner setup
**Runner**: self-hosted local PC with Claude Code

### Verification
- OK `npm run typecheck`
- OK `npm run lint`
- OK `npm run build`

### Files changed
- `ocs/repo-guide.md`

### Claude summary
## Summary

Added a new **"Autonomous Local Runner"** section to `docs/repo-guide.md` (lines 124–142). It explains:

- The `autonomous-agent.yml` workflow runs on a self-hosted PC runner labelled **`my-app-local`**.
- The runner uses a **local Claude Code login** (not an API key secret).
- A preflight `claude auth status` check skips execution if the session isn't authenticated.
- Three setup steps to register and prepare the runner.

## Checks

- Change is documentation-only (single `.md` file edit).
- No code, test, or workflow files modified.
- Content is consistent with `.github/workflows/autonomous-agent.yml` (runner labels, auth check, skip behaviour).

Closes #1