### PR TITLE
refactor: judgesystemスケーラブルアーキテクチャ改善 (#4)

### DIFF
--- a/judgesystem/source/bid_apps/postgres/backend/app/index.ts
+++ b/judgesystem/source/bid_apps/postgres/backend/app/index.ts
@@ -1,0 +1,134 @@
+import express from "express";
+import cors from "cors";
+import compression from "compression";
+import {
+  EvaluationController,
+  AnnouncementController,
+  PartnerController,
+  OrdererController,
+  ContactController,
+  CompanyController,
+} from "./src/controllers";
+import { pool } from "./src/config/database";
+import { runMigrations } from "./src/config/migrations";
+
+const app = express();
+
+app.use(cors({
+  origin: process.env.CORS_ORIGIN || "http://localhost:5173",
+  methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE", "OPTIONS"],
+  allowedHeaders: ["*"],
+  credentials: false
+}));
+
+app.options("*", cors());
+
+// gzip圧縮を有効化
+app.use(compression());
+
+// Middleware to parse JSON body (must be before routes)
+app.use(express.json());
+
+// Request logging middleware
+app.use((req, res, next) => {
+  if (req.path === "/health") return next();
+  const start = Date.now();
+  res.on("finish", () => {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      path: req.path,
+      status: res.statusCode,
+      duration: Date.now() - start
+    }));
+  });
+  next();
+});
+
+// Root path
+app.get("/", (req, res) => {
+  res.send("Backend API is running");
+});
+
+// Health check endpoint
+app.get("/health", async (req, res) => {
+  try {
+    const client = await pool.connect();
+    await client.query("SELECT 1");
+    client.release();
+    res.json({
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      database: "connected"
+    });
+  } catch {
+    res.status(503).json({ status: "unhealthy", database: "disconnected" });
+  }
+});
+
+// Initialize controllers
+const evaluationController = new EvaluationController();
+const announcementController = new AnnouncementController();
+const partnerController = new PartnerController();
+const ordererController = new OrdererController();
+const contactController = new ContactController();
+const companyController = new CompanyController();
+
+// Evaluation routes
+app.get("/api/evaluations/stats", evaluationController.getStats);
+app.get("/api/evaluations/status-counts", evaluationController.getStatusCounts);
+app.get("/api/evaluations", evaluationController.getList);
+app.get("/api/evaluations/:id", evaluationController.getById);
+app.patch("/api/evaluations/:evaluationNo", evaluationController.updateWorkStatus);
+app.get("/api/evaluations/:evaluationNo/assignees", evaluationController.getAssignees);
+app.put("/api/evaluations/:evaluationNo/assignees", evaluationController.updateAssignee);
+
+// Announcement routes
+app.get("/api/announcements", announcementController.getList);
+app.get("/api/announcements/:announcementNo", announcementController.getByNo);
+app.get("/api/announcements/:announcementNo/progressing-companies", announcementController.getProgressingCompanies);
+app.get("/api/announcements/:announcementNo/similar-cases", announcementController.getSimilarCases);
+app.get("/api/announcements/:announcementNo/documents/:documentId/preview", announcementController.getDocumentPreview);
+
+// Partner routes
+app.get("/api/partners", partnerController.getList);
+app.get("/api/partners/:id", partnerController.getById);
+
+// Orderer routes
+app.get("/api/orderers", ordererController.getList);
+app.get("/api/orderers/:id", ordererController.getById);
+
+// Contact routes
+app.get("/api/contacts", contactController.getList);
+app.get("/api/contacts/:id", contactController.getById);
+app.post("/api/contacts", contactController.create);
+app.patch("/api/contacts/:id", contactController.update);
+app.delete("/api/contacts/:id", contactController.delete);
+
+// Company routes
+app.get("/api/companies", companyController.getList);
+
+// Cloud Run は PORT 環境変数を使う
+const port = process.env.PORT || 8080;
+
+(async () => {
+  try {
+    await runMigrations();
+  } catch (err) {
+    console.error("Migration failed, starting server anyway:", err);
+  }
+
+  const server = app.listen(port, () => {
+    console.log(`API server running on port ${port}`);
+  });
+
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => {
+      console.log(`Received ${signal}, shutting down gracefully...`);
+      server.close(() => {
+        pool.end().then(() => process.exit(0));
+      });
+    });
+  }
+})();

--- a/judgesystem/source/bid_apps/postgres/backend/app/src/config/migrations.ts
+++ b/judgesystem/source/bid_apps/postgres/backend/app/src/config/migrations.ts
@@ -1,0 +1,58 @@
+import * as fs from "fs";
+import * as path from "path";
+import { pool, schemaPrefix } from "./database";
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "migrations");
+
+async function ensureMigrationsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${schemaPrefix}schema_migrations (
+      id SERIAL PRIMARY KEY,
+      filename VARCHAR(255) NOT NULL UNIQUE,
+      applied_at TIMESTAMP NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+async function getAppliedMigrations(): Promise<Set<string>> {
+  const { rows } = await pool.query(
+    `SELECT filename FROM ${schemaPrefix}schema_migrations ORDER BY id`
+  );
+  return new Set(rows.map((r: { filename: string }) => r.filename));
+}
+
+export async function runMigrations(): Promise<void> {
+  await ensureMigrationsTable();
+
+  const applied = await getAppliedMigrations();
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    if (applied.has(file)) {
+      continue;
+    }
+
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf-8");
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(sql);
+      await client.query(
+        `INSERT INTO ${schemaPrefix}schema_migrations (filename) VALUES ($1)`,
+        [file]
+      );
+      await client.query("COMMIT");
+      console.log(`Migration applied: ${file}`);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      console.error(`Migration failed: ${file}`, err);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/judgesystem/source/bid_apps/postgres/backend/app/src/migrations/001_add_indexes.sql
+++ b/judgesystem/source/bid_apps/postgres/backend/app/src/migrations/001_add_indexes.sql
@@ -1,0 +1,7 @@
+CREATE INDEX IF NOT EXISTS idx_cbj_announcement_no ON company_bid_judgement(announcement_no);
+CREATE INDEX IF NOT EXISTS idx_cbj_company_office ON company_bid_judgement(company_no, office_no);
+CREATE INDEX IF NOT EXISTS idx_req_announcement_no ON bid_requirements(announcement_no);
+CREATE INDEX IF NOT EXISTS idx_doc_announcement_id ON bid_announcements_document_table(announcement_id);
+CREATE INDEX IF NOT EXISTS idx_eval_status ON backend_evaluation_statuses(evaluation_no);
+CREATE INDEX IF NOT EXISTS idx_suf_req ON sufficient_requirements(announcement_no, company_no, office_no);
+CREATE INDEX IF NOT EXISTS idx_insuf_req ON insufficient_requirements(announcement_no, company_no, office_no);

--- a/judgesystem/source/bid_apps/postgres/backend/app/src/repositories/announcementRepository.ts
+++ b/judgesystem/source/bid_apps/postgres/backend/app/src/repositories/announcementRepository.ts
@@ -1,0 +1,562 @@
+import { PoolClient } from "pg";
+import { pool, TABLES, schemaPrefix } from "../config/database";
+import { FilterParams } from "../types";
+import { downloadFileFromGCS, readMultipleMarkdownFromGCS } from "../utils/gcs";
+
+export class AnnouncementRepository {
+  private getStatusExpression(): string {
+    return `
+      CASE
+        WHEN COALESCE(cbj.final_status, FALSE) THEN 'all_met'
+        WHEN
+          COALESCE(cbj.requirement_ineligibility, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_grade_item, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_location, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_experience, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_technician, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_other, FALSE) = FALSE
+        THEN 'other_only_unmet'
+        ELSE 'unmet'
+      END
+    `;
+  }
+
+  /**
+   * Get paginated announcements list with filters
+   * bid_announcements テーブルから一覧表示に必要な最小限のデータを取得
+   */
+  async findWithFilters(filters: FilterParams): Promise<{ data: any[]; total: number }> {
+    const client = await pool.connect();
+    try {
+      // Build WHERE clause
+      const { whereClause, queryParams, paramIndex } = this.buildWhereClause(filters);
+
+      // Get total count
+      const countQuery = `
+        SELECT COUNT(*) as count
+        FROM ${schemaPrefix}bid_announcements
+        ${whereClause}
+      `;
+      const countResult = await client.query(countQuery, queryParams);
+      const total = parseInt(countResult.rows[0].count);
+
+      // Build ORDER BY clause
+      const orderByClause = this.buildOrderByClause(filters.sortField, filters.sortOrder);
+
+      // Get paginated data
+      const page = filters.page || 0;
+      const pageSize = filters.pageSize || 25;
+      const offset = page * pageSize;
+
+      // 一覧表示に必要な最小限のフィールドのみ取得
+      const dataQuery = `
+        SELECT
+          CONCAT('ann-', announcement_no) AS id,
+          announcement_no AS "announcementNo",
+          COALESCE("workName", '') AS title,
+          COALESCE("topAgencyName", '') AS organization,
+          COALESCE(category, '') AS category,
+          COALESCE("bidType", 'unknown') AS "bidType",
+          COALESCE("workPlace", '') AS "workLocation",
+          COALESCE("publishDate", '') AS "publishDate",
+          COALESCE("bidEndDate", '') AS deadline,
+
+          -- ステータスを締切日から動的に計算（文字列比較で安全に）
+          CASE
+            -- 締切が有効な日付形式でない場合は closed
+            WHEN "bidEndDate" IS NULL OR "bidEndDate" !~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+              THEN 'closed'
+            -- 締切まで14日以上 → upcoming (公告中) ※文字列比較
+            WHEN "bidEndDate" >= TO_CHAR(CURRENT_DATE + INTERVAL '14 days', 'YYYY-MM-DD')
+              THEN 'upcoming'
+            -- 締切前で14日以内 → ongoing (締切間近) ※文字列比較
+            WHEN "bidEndDate" >= TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')
+              THEN 'ongoing'
+            -- 締切後 → awaiting_result (結果待)
+            ELSE 'awaiting_result'
+          END AS status
+
+        FROM ${schemaPrefix}bid_announcements
+        ${whereClause}
+        ${orderByClause}
+        LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+      `;
+      const dataParams = [...queryParams, pageSize, offset];
+      const dataResult = await client.query(dataQuery, dataParams);
+
+      return {
+        data: dataResult.rows,
+        total,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Find single announcement by announcement_no
+   * bid_announcements をベースに、documents と competing_companies を取得
+   */
+  async findByNo(announcementNo: number): Promise<any | null> {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `
+        WITH
+        -- documents を集約
+        documents_agg AS (
+          SELECT
+            announcement_id,
+            jsonb_agg(
+              jsonb_build_object(
+                'id', document_id,
+                'type', type,
+                'title', title,
+                'fileFormat', "fileFormat",
+                'pageCount', "pageCount",
+                'extractedAt', "extractedAt",
+                'url', COALESCE(REPLACE(save_path, 'gs://', 'https://storage.googleapis.com/'), url),
+                'markdown_path', markdown_path
+              ) ORDER BY document_id
+            ) AS documents
+          FROM ${schemaPrefix}announcements_documents_master
+          WHERE announcement_id = $1
+          GROUP BY announcement_id
+        ),
+        -- competing companies を集約
+        competing_companies_agg AS (
+          SELECT
+            cc.announcement_id,
+            jsonb_agg(
+              jsonb_build_object(
+                'name', cc.company_name,
+                'isWinner', cc."isWinner",
+                'bidAmounts', COALESCE(
+                  (
+                    SELECT jsonb_agg(bid_amount ORDER BY bid_order)
+                    FROM ${schemaPrefix}announcements_competing_company_bids_master b
+                    WHERE b.announcement_id = cc.announcement_id
+                      AND b.company_name = cc.company_name
+                  ),
+                  '[]'::jsonb
+                )
+              ) ORDER BY cc.company_name
+            ) AS competing_companies
+          FROM ${schemaPrefix}announcements_competing_companies_master cc
+          WHERE cc.announcement_id = $1
+          GROUP BY cc.announcement_id
+        )
+        SELECT
+          CONCAT('ann-', a.announcement_no) AS id,
+          a.announcement_no AS "no",
+          a.announcement_no AS "announcementNo",
+          COALESCE(a.orderer_id, '') AS "ordererId",
+          COALESCE(a."workName", '') AS title,
+          COALESCE(a."topAgencyName", '') AS organization,
+          COALESCE(a.category, '') AS category,
+          COALESCE(a."bidType", 'unknown') AS "bidType",
+          COALESCE(a."workPlace", '') AS "workLocation",
+
+          -- department を JSONB オブジェクトとして構築
+          jsonb_build_object(
+            'postalCode', COALESCE(a.zipcode, ''),
+            'address', COALESCE(a.address, ''),
+            'name', COALESCE(a.department, ''),
+            'contactPerson', COALESCE(a."assigneeName", ''),
+            'phone', COALESCE(a.telephone, ''),
+            'fax', COALESCE(a.fax, ''),
+            'email', COALESCE(a.mail, '')
+          ) AS department,
+
+          COALESCE(a."publishDate", '') AS "publishDate",
+          COALESCE(a."docDistStart", '') AS "explanationStartDate",
+          COALESCE(a."docDistEnd", '') AS "explanationEndDate",
+          COALESCE(a."submissionStart", '') AS "applicationStartDate",
+          COALESCE(a."submissionEnd", '') AS "applicationEndDate",
+          COALESCE(a."bidStartDate", '') AS "bidStartDate",
+          COALESCE(a."bidEndDate", '') AS "bidEndDate",
+          COALESCE(a."bidEndDate", '') AS deadline,
+
+          -- ステータスを締切日から動的に計算（文字列比較で安全に）
+          CASE
+            WHEN a."bidEndDate" IS NULL OR a."bidEndDate" !~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+              THEN 'closed'
+            WHEN a."bidEndDate" >= TO_CHAR(CURRENT_DATE + INTERVAL '14 days', 'YYYY-MM-DD')
+              THEN 'upcoming'
+            WHEN a."bidEndDate" >= TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')
+              THEN 'ongoing'
+            ELSE 'awaiting_result'
+          END AS status,
+
+          -- 見積金額・落札金額（今後別テーブルから取得予定、現在は NULL）
+          NULL::integer AS "estimatedAmountMin",
+          NULL::integer AS "estimatedAmountMax",
+          NULL::integer AS "actualAmount",
+          NULL::text AS "winningCompanyId",
+          NULL::text AS "winningCompanyName",
+
+          -- documents と competing_companies
+          COALESCE(d.documents, '[]'::jsonb) AS documents,
+          COALESCE(cc.competing_companies, '[]'::jsonb) AS "competingCompanies"
+
+        FROM ${schemaPrefix}bid_announcements a
+        LEFT JOIN documents_agg d ON d.announcement_id = a.announcement_no
+        LEFT JOIN competing_companies_agg cc ON cc.announcement_id = a.announcement_no
+        WHERE a.announcement_no = $1
+        `,
+        [announcementNo]
+      );
+
+      if (result.rowCount === 0) {
+        return null;
+      }
+
+      const announcement = result.rows[0];
+
+      // documents の各アイテムについて、markdown_path から content を並列一括取得
+      if (announcement.documents && Array.isArray(announcement.documents)) {
+        const fallback = '文字起こしデータがありません';
+
+        // GCS パスを収集し、有効なパスのインデックスを記録
+        const gcsPaths: string[] = [];
+        const gcsIndexMap: number[] = [];
+        announcement.documents.forEach((doc: any, i: number) => {
+          if (doc.markdown_path && doc.markdown_path.startsWith('gs://')) {
+            gcsPaths.push(doc.markdown_path);
+            gcsIndexMap.push(i);
+          }
+        });
+
+        // 全 GCS パスを並列で一括取得（個別失敗はフォールバック値）
+        const contents = await readMultipleMarkdownFromGCS(gcsPaths, fallback);
+
+        // 結果をドキュメントにマッピング
+        announcement.documents = announcement.documents.map((doc: any, i: number) => {
+          const gcsIdx = gcsIndexMap.indexOf(i);
+          const content = gcsIdx !== -1 ? contents[gcsIdx] : fallback;
+          return { ...doc, content, markdown_path: undefined };
+        });
+      }
+
+      return announcement;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get progressing companies (in_progress / completed) for a given announcement
+   */
+  async findProgressingCompanies(announcementNo: number): Promise<any[]> {
+    const client = await pool.connect();
+    try {
+      const statusExpression = this.getStatusExpression();
+      const result = await client.query(
+        `
+        SELECT
+          cbj.evaluation_no::text AS "evaluationId",
+          cbj.announcement_no::text AS "announcementNo",
+          cbj.company_no::text AS "companyId",
+          COALESCE(cm.company_name, '') AS "companyName",
+          cbj.office_no::text AS "branchId",
+          COALESCE(om.office_name, '') AS "branchName",
+          COALESCE(om.office_address, '') AS "branchAddress",
+          COALESCE(cm.company_address, '') AS "companyAddress",
+          1 AS priority,
+          COALESCE(evs."workStatus", 'not_started') AS "workStatus",
+          ${statusExpression} AS "evaluationStatus",
+          COALESCE(evs."updatedAt", cbj."updatedDate"::timestamptz) AS "updatedAt"
+        FROM ${schemaPrefix}company_bid_judgement cbj
+        JOIN ${schemaPrefix}company_master cm
+          ON cm.company_no::text = cbj.company_no::text
+        LEFT JOIN ${schemaPrefix}office_master om
+          ON om.office_no::text = cbj.office_no::text
+        LEFT JOIN ${schemaPrefix}${TABLES.evaluationStatuses} evs
+          ON evs."evaluationNo" = cbj.evaluation_no::text
+        WHERE cbj.announcement_no = $1
+          AND COALESCE(evs."workStatus", 'not_started') = ANY($2::text[])
+        ORDER BY COALESCE(evs."updatedAt", cbj."updatedDate"::timestamptz) DESC NULLS LAST
+        `,
+        [announcementNo, ['in_progress', 'completed']]
+      );
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get similar cases for a specific announcement (by announcement_no)
+   */
+  async findSimilarCases(announcementNo: number): Promise<any[]> {
+    const client = await pool.connect();
+    try {
+      const announcementIdCandidates = [`ann-${announcementNo}`, String(announcementNo)];
+      const tableSimilarCases = `${schemaPrefix}similar_cases_master`;
+      const tableCompetitors = `${schemaPrefix}similar_cases_competitors`;
+
+      const result = await client.query(
+        `
+        WITH filtered_cases AS (
+          SELECT
+            announcement_id::text AS announcement_id,
+            similar_case_announcement_id::text AS similar_case_announcement_id,
+            COALESCE(case_name, '') AS case_name,
+            COALESCE(winning_company, '') AS winning_company,
+            winning_amount
+          FROM ${tableSimilarCases}
+          WHERE announcement_id::text = ANY($1::text[])
+        ),
+        competitors AS (
+          SELECT
+            similar_case_announcement_id::text AS similar_case_announcement_id,
+            jsonb_agg(competitor_name ORDER BY competitor_name) AS names
+          FROM ${tableCompetitors}
+          WHERE similar_case_announcement_id::text IN (
+            SELECT similar_case_announcement_id FROM filtered_cases
+          )
+          GROUP BY similar_case_announcement_id
+        )
+        SELECT
+          sc.announcement_id,
+          sc.similar_case_announcement_id,
+          sc.case_name,
+          sc.winning_company,
+          sc.winning_amount,
+          COALESCE(comp.names, '[]'::jsonb) AS competitors
+        FROM filtered_cases sc
+        LEFT JOIN competitors comp
+          ON comp.similar_case_announcement_id = sc.similar_case_announcement_id
+        ORDER BY sc.case_name
+        `,
+        [announcementIdCandidates]
+      );
+
+      return result.rows.map(row => ({
+        id: row.similar_case_announcement_id ?? row.announcement_id,
+        announcementId: row.announcement_id,
+        similarAnnouncementId: row.similar_case_announcement_id,
+        caseName: row.case_name,
+        winningCompany: row.winning_company,
+        winningAmount: row.winning_amount,
+        competitors: row.competitors ?? [],
+      }));
+    } catch (error) {
+      console.error(`ERROR fetching similar cases for announcement ${announcementNo}:`, error);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Build WHERE clause from filters
+   * bid_announcements テーブルのカラム名に対応
+   */
+  private buildWhereClause(filters: FilterParams): {
+    whereClause: string;
+    queryParams: any[];
+    paramIndex: number;
+  } {
+    const whereClauses: string[] = [];
+    const queryParams: any[] = [];
+    let paramIndex = 1;
+
+    // ステータスフィルター（文字列比較で安全に）
+    if (filters.statuses && filters.statuses.length > 0) {
+      const statusConditions = filters.statuses.map(status => {
+        switch (status) {
+          case 'upcoming':
+            return `(
+              "bidEndDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+              AND "bidEndDate" >= TO_CHAR(CURRENT_DATE + INTERVAL '14 days', 'YYYY-MM-DD')
+            )`;
+          case 'ongoing':
+            return `(
+              "bidEndDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+              AND "bidEndDate" >= TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')
+              AND "bidEndDate" < TO_CHAR(CURRENT_DATE + INTERVAL '14 days', 'YYYY-MM-DD')
+            )`;
+          case 'awaiting_result':
+            return `(
+              "bidEndDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+              AND "bidEndDate" < TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')
+            )`;
+          case 'closed':
+            return `(
+              "bidEndDate" IS NULL
+              OR "bidEndDate" !~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+            )`;
+          default:
+            return 'FALSE';
+        }
+      }).join(' OR ');
+      whereClauses.push(`(${statusConditions})`);
+    }
+
+    if (filters.bidTypes && filters.bidTypes.length > 0) {
+      // 'unknown' が含まれている場合は NULL や空文字も含める
+      if (filters.bidTypes.includes('unknown')) {
+        const otherTypes = filters.bidTypes.filter(t => t !== 'unknown');
+        if (otherTypes.length > 0) {
+          whereClauses.push(
+            `("bidType" = ANY($${paramIndex}) OR "bidType" IS NULL OR "bidType" = '')`
+          );
+          queryParams.push(otherTypes);
+          paramIndex++;
+        } else {
+          // 'unknown' のみの場合
+          whereClauses.push(`("bidType" IS NULL OR "bidType" = '')`);
+        }
+      } else {
+        whereClauses.push(`"bidType" = ANY($${paramIndex})`);
+        queryParams.push(filters.bidTypes);
+        paramIndex++;
+      }
+    }
+
+    if (filters.categories && filters.categories.length > 0) {
+      whereClauses.push(`category = ANY($${paramIndex})`);
+      queryParams.push(filters.categories);
+      paramIndex++;
+    }
+
+    if (filters.organizations && filters.organizations.length > 0) {
+      whereClauses.push(`"topAgencyName" = ANY($${paramIndex})`);
+      queryParams.push(filters.organizations);
+      paramIndex++;
+    }
+
+    if (filters.prefectures && filters.prefectures.length > 0) {
+      const prefLikes = filters.prefectures
+        .map((_, i) => `"workPlace" ILIKE $${paramIndex + i}`)
+        .join(' OR ');
+      whereClauses.push(`(${prefLikes})`);
+      filters.prefectures.forEach(p => queryParams.push(`%${p}%`));
+      paramIndex += filters.prefectures.length;
+    }
+
+    if (filters.searchQuery && filters.searchQuery.trim()) {
+      whereClauses.push(
+        `("workName" ILIKE $${paramIndex} OR ` +
+        `"topAgencyName" ILIKE $${paramIndex} OR ` +
+        `category ILIKE $${paramIndex})`
+      );
+      queryParams.push(`%${filters.searchQuery}%`);
+      paramIndex++;
+    }
+
+    if (filters.ordererId) {
+      whereClauses.push(`orderer_id = $${paramIndex}`);
+      queryParams.push(filters.ordererId);
+      paramIndex++;
+    }
+
+    const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+
+    return { whereClause, queryParams, paramIndex };
+  }
+
+  /**
+   * Build ORDER BY clause
+   * bid_announcements テーブルのカラム名に対応
+   */
+  private buildOrderByClause(sortField?: string, sortOrder?: string): string {
+    if (!sortField) return '';
+
+    const direction = sortOrder === 'desc' ? 'DESC' : 'ASC';
+    const fieldMap: Record<string, string> = {
+      announcementNo: 'announcement_no',
+      no: 'announcement_no',
+      status: `(
+        CASE
+          WHEN "bidEndDate" IS NULL OR "bidEndDate" !~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+            THEN 4
+          WHEN "bidEndDate" >= TO_CHAR(CURRENT_DATE + INTERVAL '14 days', 'YYYY-MM-DD')
+            THEN 1
+          WHEN "bidEndDate" >= TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD')
+            THEN 2
+          ELSE 3
+        END
+      )`,
+      bidType: '"bidType"',
+      title: '"workName"',
+      organization: '"topAgencyName"',
+      category: 'category',
+      publishDate: `
+        CASE
+          WHEN "publishDate" IS NULL OR "publishDate" = '' THEN NULL
+          WHEN "publishDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$' THEN "publishDate"
+          ELSE NULL
+        END
+      `,
+      deadline: `
+        CASE
+          WHEN "bidEndDate" IS NULL OR "bidEndDate" = '' THEN NULL
+          WHEN "bidEndDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$' THEN "bidEndDate"
+          ELSE NULL
+        END
+      `,
+      workLocation: '"workPlace"',
+      prefecture: '"workPlace"',
+    };
+
+    if (fieldMap[sortField]) {
+      return `ORDER BY ${fieldMap[sortField]} ${direction} NULLS LAST`;
+    }
+
+    return '';
+  }
+
+  /**
+   * 指定した資料ファイルを GCS から取得
+   */
+  async getDocumentFile(announcementNo: number, documentId: string): Promise<{ data: Buffer; fileFormat: string; title: string } | null> {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `
+        SELECT
+          document_id,
+          title,
+          "fileFormat",
+          save_path,
+          url
+        FROM ${schemaPrefix}announcements_documents_master
+        WHERE announcement_id = $1
+          AND document_id = $2
+        `,
+        [announcementNo, documentId]
+      );
+
+      if (result.rowCount === 0) {
+        return null;
+      }
+
+      const row = result.rows[0] as {
+        document_id: number;
+        title: string;
+        fileFormat: string | null;
+        save_path: string | null;
+        url: string | null;
+      };
+
+      const gcsPath = row.save_path?.startsWith('gs://') ? row.save_path : undefined;
+      if (!gcsPath) {
+        const message = `Document ${documentId} for announcement ${announcementNo} has no GCS save_path`;
+        console.warn(message);
+        throw new Error("Document file not found in storage");
+      }
+
+      const fileBuffer = await downloadFileFromGCS(gcsPath);
+
+      return {
+        data: fileBuffer,
+        fileFormat: row.fileFormat || 'pdf',
+        title: row.title || `document-${row.document_id}`,
+      };
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/judgesystem/source/bid_apps/postgres/backend/app/src/repositories/evaluationRepository.ts
+++ b/judgesystem/source/bid_apps/postgres/backend/app/src/repositories/evaluationRepository.ts
@@ -1,0 +1,662 @@
+import { pool, TABLES, schemaPrefix } from "../config/database";
+import { readMultipleMarkdownFromGCS } from "../utils/gcs";
+import { FilterParams } from "../types";
+
+type QualifiedTables = {
+  companyBidJudgement: string;
+  bidAnnouncements: string;
+  companyMaster: string;
+  officeMaster: string;
+  documents: string;
+  requirements: string;
+  sufficientRequirements: string;
+  insufficientRequirements: string;
+  competingCompanies: string;
+  competingCompanyBids: string;
+  announcementsEstimatedAmounts: string;
+  evaluationStatuses: string;
+  evaluationAssignees: string;
+};
+
+export class EvaluationRepository {
+  /**
+   * Get paginated evaluations list with filters
+   */
+  async findWithFilters(filters: FilterParams): Promise<{ data: any[]; total: number }> {
+    const client = await pool.connect();
+    try {
+      const tables = this.getQualifiedTables();
+      const baseFromClause = this.getBaseFromClause(tables);
+      const statusExpression = this.getStatusExpression();
+      const workStatusExpression = this.getWorkStatusExpression();
+      const currentStepExpression = this.getCurrentStepExpression();
+      const priorityExpression = this.getPriorityExpression();
+
+      // Build WHERE clause
+      const { whereClause, queryParams, paramIndex } = this.buildWhereClause(
+        filters,
+        statusExpression,
+        workStatusExpression
+      );
+
+      // Get total count
+      const countQuery = `SELECT COUNT(*) as count ${baseFromClause} ${whereClause}`;
+      const countResult = await client.query(countQuery, queryParams);
+      const total = parseInt(countResult.rows[0].count);
+
+      // Build ORDER BY clause
+      const orderByClause = this.buildOrderByClause(
+        filters.sortField,
+        filters.sortOrder,
+        statusExpression,
+        workStatusExpression,
+        priorityExpression
+      );
+
+      // Get paginated data
+      const page = filters.page || 0;
+      const pageSize = filters.pageSize || 25;
+      const offset = page * pageSize;
+
+      const dataQuery = `
+        SELECT
+          cbj.evaluation_no::text AS id,
+          cbj.evaluation_no::text AS "evaluationNo",
+          jsonb_build_object(
+            'title', COALESCE(ba."workName", ''),
+            'organization', COALESCE(ba."topAgencyName", ''),
+            'category', COALESCE(ba.category, ''),
+            'bidType', COALESCE(ba."bidType", ''),
+            'deadline', COALESCE(ba."bidEndDate", ''),
+            'workLocation', COALESCE(ba."workPlace", ''),
+            'estimatedAmountMin', aea.estimated_amount_min,
+            'estimatedAmountMax', aea.estimated_amount_max
+          ) AS announcement,
+          jsonb_build_object(
+            'name', COALESCE(cm.company_name, ''),
+            'priority', ${priorityExpression}
+          ) AS company,
+          jsonb_build_object(
+            'id', CONCAT('brn-', cbj.office_no),
+            'name', COALESCE(om.office_name, ''),
+            'address', COALESCE(om.office_address, ''),
+            'phone', COALESCE(om.office_telephone, ''),
+            'email', COALESCE(om.office_email, ''),
+            'fax', COALESCE(om.office_fax, ''),
+            'postalCode', COALESCE(om.office_postal_code, '')
+          ) AS branch,
+          ${statusExpression} AS status,
+          ${workStatusExpression} AS "workStatus",
+          ${currentStepExpression} AS "currentStep",
+          cbj."updatedDate" AS "evaluatedAt"
+        ${baseFromClause}
+        ${whereClause}
+        ${orderByClause || "ORDER BY cbj.evaluation_no DESC"}
+        LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+      `;
+      const dataParams = [...queryParams, pageSize, offset];
+      const dataResult = await client.query(dataQuery, dataParams);
+
+      return {
+        data: dataResult.rows,
+        total,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Find single evaluation by ID
+   */
+  async findById(id: string): Promise<any | null> {
+    const client = await pool.connect();
+    try {
+      const tables = this.getQualifiedTables();
+      const statusExpression = this.getStatusExpression();
+      const workStatusExpression = this.getWorkStatusExpression();
+      const currentStepExpression = this.getCurrentStepExpression();
+      const priorityExpression = this.getPriorityExpression();
+      const baseFromClause = this.getBaseFromClause(tables);
+
+      const result = await client.query(
+        `
+        WITH documents AS (
+          SELECT
+            announcement_id,
+            jsonb_agg(
+              jsonb_build_object(
+                'id', document_id,
+                'type', type,
+                'title', title,
+                'fileFormat', "fileFormat",
+                'pageCount', "pageCount",
+                'extractedAt', "extractedAt",
+                'url', COALESCE(REPLACE(save_path, 'gs://', 'https://storage.googleapis.com/'), url),
+                'markdown_path', markdown_path
+              )
+              ORDER BY document_id
+            ) AS docs
+          FROM ${tables.documents}
+          GROUP BY announcement_id
+        ),
+        company_bids AS (
+          SELECT
+            announcement_id,
+            company_name,
+            jsonb_agg(bid_amount ORDER BY bid_order) AS bid_amounts
+          FROM ${tables.competingCompanyBids}
+          GROUP BY announcement_id, company_name
+        ),
+        competing_companies AS (
+          SELECT
+            cc.announcement_id,
+            jsonb_agg(
+              jsonb_build_object(
+                'name', cc.company_name,
+                'isWinner', cc."isWinner",
+                'bidAmounts', COALESCE(cb.bid_amounts, '[]'::jsonb)
+              )
+              ORDER BY cc.company_name
+            ) AS companies,
+            MAX(CASE WHEN cc."isWinner" THEN cc.company_name END) AS winning_company_name,
+            MAX(
+              CASE WHEN cc."isWinner" THEN (
+                SELECT bid_amount
+                FROM ${tables.competingCompanyBids} b
+                WHERE b.announcement_id = cc.announcement_id
+                  AND b.company_name = cc.company_name
+                ORDER BY bid_order DESC
+                LIMIT 1
+              ) END
+            ) AS winning_company_amount
+          FROM ${tables.competingCompanies} cc
+          LEFT JOIN company_bids cb
+            ON cb.announcement_id = cc.announcement_id
+           AND cb.company_name = cc.company_name
+         GROUP BY cc.announcement_id
+        ),
+        step_assignees AS (
+          SELECT
+            evaluation_no,
+            jsonb_agg(
+              jsonb_build_object(
+                'stepId', step_id,
+                'staffId', contact_id::text,
+                'assignedAt', assigned_at
+              )
+              ORDER BY step_id
+            ) AS assignees
+          FROM ${tables.evaluationAssignees}
+          GROUP BY evaluation_no
+        ),
+        requirement_details AS (
+          SELECT
+            req1.announcement_no,
+            req2.office_no,
+            jsonb_agg(
+              jsonb_build_object(
+                'id', CONCAT('req-', req1.requirement_no),
+                'category', req2.requirement_type,
+                'name', req1.requirement_text,
+                'isMet', req2.is_met,
+                'reason', req2.requirement_description,
+                'evidence', 'dummy_evidence'
+              )
+              ORDER BY req1.requirement_no
+            ) AS requirements
+          FROM ${tables.requirements} req1
+          JOIN (
+            SELECT
+              announcement_no,
+              office_no,
+              requirement_no,
+              requirement_type,
+              requirement_description,
+              TRUE AS is_met
+            FROM ${tables.sufficientRequirements}
+            UNION ALL
+            SELECT
+              announcement_no,
+              office_no,
+              requirement_no,
+              requirement_type,
+              requirement_description,
+              FALSE AS is_met
+            FROM ${tables.insufficientRequirements}
+          ) req2
+            ON req1.requirement_no = req2.requirement_no
+          GROUP BY req1.announcement_no, req2.office_no
+        )
+        SELECT
+          cbj.evaluation_no::text AS id,
+          cbj.evaluation_no::text AS "evaluationNo",
+          jsonb_build_object(
+            'id', CONCAT('ann-', cbj.announcement_no),
+            'ordererId', COALESCE(ba.orderer_id::text, ''),
+            'title', COALESCE(ba."workName", ''),
+            'category', COALESCE(ba.category, ''),
+            'organization', COALESCE(ba."topAgencyName", ''),
+            'workLocation', COALESCE(ba."workPlace", ''),
+            'department', jsonb_build_object(
+              'postalCode', COALESCE(ba.zipcode, ''),
+              'address', COALESCE(ba.address, ''),
+              'name', COALESCE(ba.department, ''),
+              'contactPerson', COALESCE(ba."assigneeName", ''),
+              'phone', COALESCE(ba.telephone, ''),
+              'fax', COALESCE(ba.fax, ''),
+              'email', COALESCE(ba.mail, '')
+            ),
+            'publishDate', COALESCE(ba."publishDate", ''),
+            'explanationStartDate', COALESCE(ba."docDistStart", ''),
+            'explanationEndDate', COALESCE(ba."docDistEnd", ''),
+            'applicationStartDate', COALESCE(ba."submissionStart", ''),
+            'applicationEndDate', COALESCE(ba."submissionEnd", ''),
+            'bidStartDate', COALESCE(ba."bidStartDate", ''),
+            'bidEndDate', COALESCE(ba."bidEndDate", ''),
+            'deadline', COALESCE(ba."bidEndDate", ''),
+            'estimatedAmountMin', aea.estimated_amount_min,
+            'estimatedAmountMax', aea.estimated_amount_max,
+            'pdfUrl', COALESCE(doc.docs->0->>'url', ''),
+            'documents', COALESCE(doc.docs, '[]'::jsonb),
+            'competingCompanies', COALESCE(companies.companies, '[]'::jsonb),
+            'winningCompanyId', NULL,
+            'winningCompanyName', COALESCE(companies.winning_company_name, ''),
+            'actualAmount', companies.winning_company_amount
+          ) AS announcement,
+          jsonb_build_object(
+            'id', CONCAT('com-', cbj.company_no),
+            'name', COALESCE(cm.company_name, ''),
+            'address', COALESCE(cm.company_address, ''),
+            'grade', 'A',
+            'priority', ${priorityExpression}
+          ) AS company,
+          jsonb_build_object(
+            'id', CONCAT('brn-', cbj.office_no),
+            'name', COALESCE(om.office_name, ''),
+            'address', COALESCE(om.office_address, ''),
+            'phone', COALESCE(om.office_telephone, ''),
+            'email', COALESCE(om.office_email, ''),
+            'fax', COALESCE(om.office_fax, ''),
+            'postalCode', COALESCE(om.office_postal_code, '')
+          ) AS branch,
+          COALESCE(sa.assignees, '[]'::jsonb) AS "stepAssignees",
+          COALESCE(req.requirements, '[]'::jsonb) AS requirements,
+          ${statusExpression} AS status,
+          ${workStatusExpression} AS "workStatus",
+          ${currentStepExpression} AS "currentStep",
+          cbj."updatedDate" AS "evaluatedAt"
+        ${baseFromClause}
+        LEFT JOIN documents doc ON doc.announcement_id::text = cbj.announcement_no::text
+        LEFT JOIN competing_companies companies ON companies.announcement_id::text = cbj.announcement_no::text
+        LEFT JOIN requirement_details req
+          ON req.announcement_no::text = cbj.announcement_no::text
+         AND COALESCE(req.office_no::text, '-1') = COALESCE(cbj.office_no::text, '-1')
+        LEFT JOIN step_assignees sa ON sa.evaluation_no::text = cbj.evaluation_no::text
+        WHERE cbj.evaluation_no::text = $1
+        `,
+        [id]
+      );
+
+      if (result.rowCount === 0) {
+        return null;
+      }
+
+      const evaluation = result.rows[0];
+
+      if (
+        evaluation?.announcement?.documents &&
+        Array.isArray(evaluation.announcement.documents)
+      ) {
+        evaluation.announcement.documents = await this.attachDocumentContents(
+          evaluation.announcement.documents
+        );
+      }
+
+      return evaluation;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Update workStatus for an evaluation
+   */
+  async updateWorkStatus(
+    evaluationNo: string,
+    workStatus: string,
+    currentStep?: string
+  ): Promise<any | null> {
+    const client = await pool.connect();
+    try {
+      const qualifiedTableName = `${schemaPrefix}${TABLES.evaluationStatuses}`;
+
+      const result = await client.query(
+        `INSERT INTO ${qualifiedTableName} AS status ("evaluationNo", "workStatus", "currentStep")
+         VALUES ($1, $2, COALESCE($3, 'judgment'))
+         ON CONFLICT ("evaluationNo") DO UPDATE
+         SET "workStatus" = EXCLUDED."workStatus",
+             "currentStep" = CASE WHEN $3 IS NULL THEN status."currentStep" ELSE EXCLUDED."currentStep" END,
+             "updatedAt" = NOW()
+         RETURNING "evaluationNo", "workStatus", "currentStep", "updatedAt"`,
+        [evaluationNo, workStatus, currentStep ?? null]
+      );
+
+      return result.rowCount === 0 ? null : result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get statistics for analytics dashboard
+   */
+  async getStats(): Promise<any> {
+    const client = await pool.connect();
+    try {
+      const tables = this.getQualifiedTables();
+      const baseFromClause = this.getBaseFromClause(tables);
+      const statusExpression = this.getStatusExpression();
+
+      const result = await client.query(`
+        WITH base AS (
+          SELECT
+            ${statusExpression} AS status,
+            COALESCE(ba."topAgencyName", '') AS organization,
+            COALESCE(ba.category, '') AS category
+          ${baseFromClause}
+        )
+        SELECT
+          COUNT(*) AS total,
+          COUNT(*) FILTER (WHERE status = 'all_met') AS "allMet",
+          COUNT(*) FILTER (WHERE status = 'other_only_unmet') AS "otherUnmet",
+          COUNT(*) FILTER (WHERE status = 'unmet') AS "unmet",
+          (
+            SELECT jsonb_agg(org_stats ORDER BY count DESC)
+            FROM (
+              SELECT
+                SPLIT_PART(organization, ' ', 1) AS organization,
+                COUNT(*) AS count
+              FROM base
+              GROUP BY SPLIT_PART(organization, ' ', 1)
+              ORDER BY COUNT(*) DESC
+              LIMIT 5
+            ) org_stats
+          ) AS "topOrganizations",
+          (
+            SELECT COUNT(DISTINCT SPLIT_PART(organization, ' ', 1))
+            FROM base
+          ) AS "organizationCount",
+          (
+            SELECT jsonb_agg(cat_stats ORDER BY count DESC)
+            FROM (
+              SELECT
+                category,
+                COUNT(*) AS count
+              FROM base
+              GROUP BY category
+              ORDER BY COUNT(*) DESC
+              LIMIT 5
+            ) cat_stats
+          ) AS "topCategories"
+        FROM base
+      `);
+
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get counts for each evaluation status based on current filters
+   */
+  async getStatusCounts(filters: FilterParams): Promise<{ all_met: number; other_only_unmet: number; unmet: number }> {
+    const client = await pool.connect();
+    try {
+      const tables = this.getQualifiedTables();
+      const baseFromClause = this.getBaseFromClause(tables);
+      const statusExpression = this.getStatusExpression();
+      const workStatusExpression = this.getWorkStatusExpression();
+
+      const { whereClause, queryParams } = this.buildWhereClause(filters, statusExpression, workStatusExpression);
+
+      const result = await client.query(
+        `
+        WITH base AS (
+          SELECT
+            ${statusExpression} AS status
+          ${baseFromClause}
+          ${whereClause}
+        )
+        SELECT
+          COUNT(*) FILTER (WHERE status = 'all_met') AS "all_met",
+          COUNT(*) FILTER (WHERE status = 'other_only_unmet') AS "other_only_unmet",
+          COUNT(*) FILTER (WHERE status = 'unmet') AS "unmet"
+        FROM base
+        `,
+        queryParams
+      );
+
+      if (result.rowCount === 0) {
+        return { all_met: 0, other_only_unmet: 0, unmet: 0 };
+      }
+
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Build WHERE clause from filters
+   */
+  private buildWhereClause(
+    filters: FilterParams,
+    statusExpression: string,
+    workStatusExpression: string
+  ): {
+    whereClause: string;
+    queryParams: any[];
+    paramIndex: number;
+  } {
+    const whereClauses: string[] = [];
+    const queryParams: any[] = [];
+    let paramIndex = 1;
+
+    if (filters.statuses && filters.statuses.length > 0) {
+      whereClauses.push(`${statusExpression} = ANY($${paramIndex})`);
+      queryParams.push(filters.statuses);
+      paramIndex++;
+    }
+
+    if (filters.workStatuses && filters.workStatuses.length > 0) {
+      whereClauses.push(`${workStatusExpression} = ANY($${paramIndex})`);
+      queryParams.push(filters.workStatuses);
+      paramIndex++;
+    }
+
+    if (filters.priorities && filters.priorities.length > 0) {
+      const priorityInts = filters.priorities
+        .map((p: string) => parseInt(p, 10))
+        .filter((p: number) => !isNaN(p));
+      if (priorityInts.length > 0) {
+        whereClauses.push(`1 = ANY($${paramIndex}::int[])`);
+        queryParams.push(priorityInts);
+        paramIndex++;
+      }
+    }
+
+    if (filters.categories && filters.categories.length > 0) {
+      whereClauses.push(`ba.category = ANY($${paramIndex})`);
+      queryParams.push(filters.categories);
+      paramIndex++;
+    }
+
+    if (filters.bidTypes && filters.bidTypes.length > 0) {
+      whereClauses.push(`ba."bidType" = ANY($${paramIndex})`);
+      queryParams.push(filters.bidTypes);
+      paramIndex++;
+    }
+
+    if (filters.organizations && filters.organizations.length > 0) {
+      whereClauses.push(`ba."topAgencyName" = ANY($${paramIndex})`);
+      queryParams.push(filters.organizations);
+      paramIndex++;
+    }
+
+    if (filters.prefectures && filters.prefectures.length > 0) {
+      const prefLikes = filters.prefectures
+        .map((_, i) => `ba."workPlace" ILIKE $${paramIndex + i}`)
+        .join(' OR ');
+      whereClauses.push(`(${prefLikes})`);
+      filters.prefectures.forEach(p => queryParams.push(`%${p}%`));
+      paramIndex += filters.prefectures.length;
+    }
+
+    if (filters.searchQuery && filters.searchQuery.trim()) {
+      whereClauses.push(
+        `(ba."workName" ILIKE $${paramIndex} OR ` +
+        `ba."topAgencyName" ILIKE $${paramIndex} OR ` +
+        `cm.company_name ILIKE $${paramIndex} OR ` +
+        `ba.category ILIKE $${paramIndex})`
+      );
+      queryParams.push(`%${filters.searchQuery}%`);
+      paramIndex++;
+    }
+
+    if (filters.ordererId) {
+      const ordererValue = Array.isArray(filters.ordererId) ? filters.ordererId[0] : filters.ordererId;
+      whereClauses.push(`ba.orderer_id = $${paramIndex}`);
+      queryParams.push(String(ordererValue));
+      paramIndex++;
+    }
+
+    const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+
+    return { whereClause, queryParams, paramIndex };
+  }
+
+  /**
+   * Build ORDER BY clause
+   */
+  private buildOrderByClause(
+    sortField: string | undefined,
+    sortOrder: string | undefined,
+    statusExpression: string,
+    workStatusExpression: string,
+    priorityExpression: string
+  ): string {
+    if (!sortField) return '';
+
+    const direction = sortOrder === 'desc' ? 'DESC' : 'ASC';
+    const fieldMap: Record<string, string> = {
+      evaluationNo: 'cbj.evaluation_no',
+      status: statusExpression,
+      workStatus: workStatusExpression,
+      priority: `${priorityExpression}`,
+      title: `ba."workName"`,
+      company: `cm.company_name`,
+      organization: `ba."topAgencyName"`,
+      category: `ba.category`,
+      bidType: `ba."bidType"`,
+      deadline: `(
+        CASE
+          WHEN ba."bidEndDate" ~ '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'
+            THEN ba."bidEndDate"
+          ELSE NULL
+        END
+      )`,
+      evaluatedAt: `cbj."updatedDate"`,
+      prefecture: `ba."workPlace"`,
+    };
+
+    if (fieldMap[sortField]) {
+      return `ORDER BY ${fieldMap[sortField]} ${direction} NULLS LAST`;
+    }
+
+    return '';
+  }
+
+  private getQualifiedTables(): QualifiedTables {
+    return {
+      companyBidJudgement: `${schemaPrefix}company_bid_judgement`,
+      bidAnnouncements: `${schemaPrefix}bid_announcements`,
+      companyMaster: `${schemaPrefix}company_master`,
+      officeMaster: `${schemaPrefix}office_master`,
+      documents: `${schemaPrefix}announcements_documents_master`,
+      requirements: `${schemaPrefix}bid_requirements`,
+      sufficientRequirements: `${schemaPrefix}sufficient_requirements`,
+      insufficientRequirements: `${schemaPrefix}insufficient_requirements`,
+      competingCompanies: `${schemaPrefix}announcements_competing_companies_master`,
+      competingCompanyBids: `${schemaPrefix}announcements_competing_company_bids_master`,
+      announcementsEstimatedAmounts: `${schemaPrefix}announcements_estimated_amounts`,
+      evaluationStatuses: `${schemaPrefix}${TABLES.evaluationStatuses}`,
+      evaluationAssignees: `${schemaPrefix}${TABLES.evaluationAssignees}`,
+    };
+  }
+
+  private getBaseFromClause(tables: QualifiedTables): string {
+    return `
+      FROM ${tables.companyBidJudgement} cbj
+      JOIN ${tables.bidAnnouncements} ba ON ba.announcement_no::text = cbj.announcement_no::text
+      JOIN ${tables.companyMaster} cm ON cm.company_no::text = cbj.company_no::text
+      LEFT JOIN ${tables.officeMaster} om ON om.office_no::text = cbj.office_no::text
+      LEFT JOIN ${tables.announcementsEstimatedAmounts} aea ON aea.announcement_no::text = cbj.announcement_no::text
+      LEFT JOIN ${tables.evaluationStatuses} evs ON evs."evaluationNo" = cbj.evaluation_no::text
+    `;
+  }
+
+  private getStatusExpression(): string {
+    return `
+      CASE
+        WHEN COALESCE(cbj.final_status, FALSE) THEN 'all_met'
+        WHEN
+          COALESCE(cbj.requirement_ineligibility, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_grade_item, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_location, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_experience, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_technician, FALSE) = TRUE
+          AND COALESCE(cbj.requirement_other, FALSE) = FALSE
+        THEN 'other_only_unmet'
+        ELSE 'unmet'
+      END
+    `;
+  }
+
+  private getWorkStatusExpression(): string {
+    return `COALESCE(evs."workStatus", 'not_started')`;
+  }
+
+  private getCurrentStepExpression(): string {
+    return `COALESCE(evs."currentStep", 'judgment')`;
+  }
+
+  private getPriorityExpression(): string {
+    return `1`;
+  }
+
+  private async attachDocumentContents(documents: any[]): Promise<any[]> {
+    const fallback = "文字起こしデータがありません";
+
+    // GCS パスを収集し、有効なパスのインデックスを記録
+    const gcsPaths: string[] = [];
+    const gcsIndexMap: number[] = [];
+    documents.forEach((doc, i) => {
+      if (doc.markdown_path && typeof doc.markdown_path === "string" && doc.markdown_path.startsWith("gs://")) {
+        gcsPaths.push(doc.markdown_path);
+        gcsIndexMap.push(i);
+      }
+    });
+
+    // 全 GCS パスを並列で一括取得（個別失敗はフォールバック値）
+    const contents = await readMultipleMarkdownFromGCS(gcsPaths, fallback);
+
+    // 結果をドキュメントにマッピング
+    return documents.map((doc, i) => {
+      const gcsIdx = gcsIndexMap.indexOf(i);
+      const content = gcsIdx !== -1 ? contents[gcsIdx] : fallback;
+      return { ...doc, content, markdown_path: undefined };
+    });
+  }
+}

--- a/judgesystem/source/bid_apps/postgres/backend/app/src/utils/gcs.ts
+++ b/judgesystem/source/bid_apps/postgres/backend/app/src/utils/gcs.ts
@@ -1,0 +1,76 @@
+import { Storage, File } from '@google-cloud/storage';
+
+// GCS クライアントを初期化
+const storage = new Storage();
+
+/**
+ * gs:// パスから GCS ファイルオブジェクトを取得
+ */
+function getGcsFile(gcsPath: string): File {
+  if (!gcsPath || !gcsPath.startsWith('gs://')) {
+    throw new Error(`Invalid GCS path: ${gcsPath}`);
+  }
+
+  const pathWithoutPrefix = gcsPath.replace('gs://', '');
+  const firstSlashIndex = pathWithoutPrefix.indexOf('/');
+
+  if (firstSlashIndex === -1) {
+    throw new Error(`Invalid GCS path format: ${gcsPath}`);
+  }
+
+  const bucketName = pathWithoutPrefix.substring(0, firstSlashIndex);
+  const filePath = pathWithoutPrefix.substring(firstSlashIndex + 1);
+
+  return storage.bucket(bucketName).file(filePath);
+}
+
+/**
+ * GCS から Markdown ファイルの内容を取得する
+ * @param gcsPath - gs://bucket-name/path/to/file.md の形式のパス
+ * @returns Markdown ファイルの内容
+ */
+export async function readMarkdownFromGCS(gcsPath: string): Promise<string> {
+  try {
+    const file = getGcsFile(gcsPath);
+    const [content] = await file.download();
+    return content.toString('utf-8');
+  } catch (error) {
+    console.error(`Failed to read from GCS: ${gcsPath}`, error);
+    throw new Error(`Failed to read markdown from GCS: ${gcsPath}`);
+  }
+}
+
+/**
+ * 任意ファイルを Buffer として取得
+ */
+export async function downloadFileFromGCS(gcsPath: string): Promise<Buffer> {
+  try {
+    const file = getGcsFile(gcsPath);
+    const [content] = await file.download();
+    return content;
+  } catch (error) {
+    console.error(`Failed to download file from GCS: ${gcsPath}`, error);
+    throw new Error(`Failed to download file from GCS: ${gcsPath}`);
+  }
+}
+
+/**
+ * 複数の GCS パスから Markdown ファイルの内容を並列で取得する
+ * 個別のファイル取得が失敗しても他のファイルには影響しない
+ * @param gcsPaths - GCS パスの配列
+ * @param fallback - 取得失敗時のフォールバック値（デフォルト: 空文字）
+ * @returns Markdown 内容の配列（順序は入力と同じ）
+ */
+export async function readMultipleMarkdownFromGCS(
+  gcsPaths: string[],
+  fallback: string = ''
+): Promise<string[]> {
+  return Promise.all(
+    gcsPaths.map(path =>
+      readMarkdownFromGCS(path).catch(error => {
+        console.error(`Failed to read from GCS (batch): ${path}`, error);
+        return fallback;
+      })
+    )
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/App.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/App.tsx
@@ -1,0 +1,84 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import { MainLayout } from './components/layout';
+import BidListPage from './pages/BidListPage';
+import BidDetailPage from './pages/BidDetailPage';
+import AnnouncementListPage from './pages/AnnouncementListPage';
+import AnnouncementDetailPage from './pages/AnnouncementDetailPage';
+import PartnerListPage from './pages/PartnerListPage';
+import PartnerDetailPage from './pages/PartnerDetailPage';
+import OrdererListPage from './pages/OrdererListPage';
+import OrdererDetailPage from './pages/OrdererDetailPage';
+import StaffListPage from './pages/StaffListPage';
+import AnalyticsPage from './pages/AnalyticsPage';
+import MasterRegisterPage from './pages/MasterRegisterPage';
+import MasterRegisterConfirmPage from './pages/MasterRegisterConfirmPage';
+import { StaffProvider } from './contexts/StaffContext';
+import { ErrorBoundary } from './components/common';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#9c27b0',
+    },
+    success: {
+      main: '#2e7d32',
+      light: '#4caf50',
+    },
+    warning: {
+      main: '#ed6c02',
+      light: '#ff9800',
+    },
+    error: {
+      main: '#d32f2f',
+      light: '#ef5350',
+    },
+  },
+  typography: {
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      '"Segoe UI"',
+      'Roboto',
+      '"Helvetica Neue"',
+      'Arial',
+      'sans-serif',
+      '"Apple Color Emoji"',
+      '"Segoe UI Emoji"',
+      '"Segoe UI Symbol"',
+    ].join(','),
+  },
+});
+
+function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <StaffProvider>
+        <Router>
+          <MainLayout>
+            <Routes>
+              <Route path="/" element={<BidListPage />} />
+              <Route path="/detail/:id" element={<BidDetailPage />} />
+              <Route path="/announcements" element={<AnnouncementListPage />} />
+              <Route path="/announcements/:id" element={<ErrorBoundary><AnnouncementDetailPage /></ErrorBoundary>} />
+              <Route path="/partners" element={<PartnerListPage />} />
+              <Route path="/partners/:id" element={<ErrorBoundary><PartnerDetailPage /></ErrorBoundary>} />
+              <Route path="/orderers" element={<OrdererListPage />} />
+              <Route path="/orderers/:id" element={<OrdererDetailPage />} />
+              <Route path="/staff" element={<StaffListPage />} />
+              <Route path="/analytics" element={<AnalyticsPage />} />
+              <Route path="/master/register" element={<MasterRegisterPage />} />
+              <Route path="/master/register/confirm" element={<MasterRegisterConfirmPage />} />
+            </Routes>
+          </MainLayout>
+        </Router>
+      </StaffProvider>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/AnnouncementHeader.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/AnnouncementHeader.tsx
@@ -1,0 +1,149 @@
+import { Box, Typography, Button, Tabs, Tab } from '@mui/material';
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { announcementStatusConfig, bidTypeConfig } from '../../data';
+import { colors, pageStyles, fontSizes, iconStyles, borderRadius } from '../../constants/styles';
+import type { BidType, AnnouncementStatus } from '../../types/announcement';
+import type { Announcement as AnnouncementType } from '../../types';
+
+export type AnnouncementDetail = AnnouncementType & {
+  announcementNo: number;
+  no: number;
+  status?: AnnouncementStatus | string;
+};
+
+export const resolveAnnouncementStatus = (status?: string | null): AnnouncementStatus => {
+  if (status && typeof status === 'string' && (announcementStatusConfig as Record<string, unknown>)[status]) {
+    return status as AnnouncementStatus;
+  }
+  return 'upcoming';
+};
+
+export const resolveBidType = (bidType?: string | null): BidType => {
+  if (bidType && typeof bidType === 'string' && (bidTypeConfig as Record<string, unknown>)[bidType]) {
+    return bidType as BidType;
+  }
+  return 'unknown';
+};
+
+interface AnnouncementHeaderProps {
+  announcement: AnnouncementDetail;
+  onBack: () => void;
+}
+
+export function AnnouncementHeader({ announcement, onBack }: AnnouncementHeaderProps) {
+  const announcementStatus = resolveAnnouncementStatus(announcement.status as string | undefined);
+  const statusConfig = announcementStatusConfig[announcementStatus];
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
+      <Box
+        sx={{
+          pl: 2,
+          borderLeft: '4px solid',
+          borderColor: statusConfig.color,
+        }}
+      >
+        {/* ステータス類 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
+          {/* 一覧に戻る */}
+          <Button
+            size="small"
+            startIcon={<ArrowBackIcon sx={iconStyles.small} />}
+            onClick={onBack}
+            sx={{
+              color: colors.text.muted,
+              fontWeight: 500,
+              fontSize: fontSizes.sm,
+              textTransform: 'none',
+              px: 1,
+              py: 0.25,
+              minWidth: 'auto',
+              '&:hover': { backgroundColor: colors.border.light },
+            }}
+          >
+            一覧に戻る
+          </Button>
+
+          {/* ステータス */}
+          <Typography
+            sx={{
+              fontSize: fontSizes.base,
+              fontWeight: 700,
+              color: statusConfig.color,
+            }}
+          >
+            {statusConfig.label}
+          </Typography>
+
+          <Typography sx={{ color: colors.border.dark }}>|</Typography>
+
+          {/* カテゴリ */}
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.primary.dark }}>
+            {announcement.category}
+          </Typography>
+
+          <Typography sx={{ color: colors.border.dark }}>|</Typography>
+
+          {/* 入札形式 */}
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.primary.dark }}>
+            {bidTypeConfig[resolveBidType(announcement.bidType)].label}
+          </Typography>
+        </Box>
+
+        {/* タイトル */}
+        <Typography sx={pageStyles.detailPageTitle}>
+          {announcement.title}
+        </Typography>
+      </Box>
+
+      {/* 右上No */}
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light, flexShrink: 0, ml: 2 }}>
+        No. {String(announcement.no).padStart(8, '0')}
+      </Typography>
+    </Box>
+  );
+}
+
+interface AnnouncementTabsProps {
+  activeTab: number;
+  onTabChange: (value: number) => void;
+  hasDocuments: boolean;
+  relatedCount: number;
+  companiesCount: number;
+}
+
+export function AnnouncementTabs({
+  activeTab,
+  onTabChange,
+  hasDocuments,
+  relatedCount,
+  companiesCount,
+}: AnnouncementTabsProps) {
+  return (
+    <Box sx={{ borderBottom: `1px solid ${colors.border.main}`, backgroundColor: colors.text.white }}>
+      <Tabs
+        value={activeTab}
+        onChange={(_, v) => onTabChange(v)}
+        sx={{
+          px: 2,
+          '& .MuiTabs-indicator': { backgroundColor: colors.primary.main, height: 2 },
+          '& .MuiTab-root': {
+            textTransform: 'none',
+            fontSize: fontSizes.md,
+            fontWeight: 500,
+            color: colors.text.muted,
+            minWidth: 'auto',
+            px: 2,
+            py: 1.5,
+            '&.Mui-selected': { color: colors.primary.main, fontWeight: 600 },
+          },
+        }}
+      >
+        <Tab label="基本情報" />
+        {hasDocuments && <Tab label="資料" />}
+        <Tab label={`関連案件 (${relatedCount})`} />
+        <Tab label={`着手企業 (${companiesCount})`} />
+      </Tabs>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/CompetingCompaniesSection.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/CompetingCompaniesSection.tsx
@@ -1,0 +1,109 @@
+import { Box, Typography } from '@mui/material';
+import { colors, fontSizes, borderRadius } from '../../constants/styles';
+import { workStatusConfig } from '../../constants/workStatus';
+import { evaluationStatusConfig } from '../../constants/status';
+import { priorityLabels, priorityColors } from '../../constants/priority';
+import { CustomPagination } from '../bid';
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../../types';
+
+export type ProgressingCompany = {
+  companyId: string;
+  companyName: string;
+  branchId: string;
+  branchName: string;
+  priority: CompanyPriority;
+  workStatus: Extract<WorkStatus, 'in_progress' | 'completed'>;
+  evaluationId: string;
+  evaluationStatus: EvaluationStatus;
+};
+
+interface CompetingCompaniesSectionProps {
+  companies: ProgressingCompany[];
+  isLoading: boolean;
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  filteredCount: number;
+  onPageChange: (page: number) => void;
+  onNavigate: (path: string) => void;
+}
+
+export function CompetingCompaniesSection({
+  companies,
+  isLoading,
+  totalCount,
+  page,
+  pageSize,
+  filteredCount,
+  onPageChange,
+  onNavigate,
+}: CompetingCompaniesSectionProps) {
+  return (
+    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {/* スクロール可能なカードグリッド */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2.5 }}>
+        {isLoading ? (
+          <Box sx={{ p: 4, textAlign: 'center', color: colors.text.light }}>
+            データを読み込み中です...
+          </Box>
+        ) : companies.length > 0 ? (
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 1.5 }}>
+            {companies.map((company) => {
+              const wsConfig = workStatusConfig[company.workStatus];
+              const pConfig = priorityColors[company.priority];
+              const esConfig = evaluationStatusConfig[company.evaluationStatus];
+              return (
+                <Box
+                  key={`${company.companyId}-${company.branchId}`}
+                  onClick={() => onNavigate(`/detail/${company.evaluationId}`)}
+                  sx={{
+                    position: 'relative',
+                    backgroundColor: colors.text.white,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${colors.border.main}`,
+                    p: 2,
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    '&:hover': { borderColor: 'rgba(59, 130, 246, 0.4)', boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)' },
+                    '&::before': {
+                      content: '""',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: '3px',
+                      backgroundColor: wsConfig.color,
+                      borderRadius: `${borderRadius.xs} 0 0 ${borderRadius.xs}`,
+                    },
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: wsConfig.color }}>{wsConfig.label}</Typography>
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: esConfig.color }}>{esConfig.label}</Typography>
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: pConfig.color, ml: 'auto' }}>{priorityLabels[company.priority]}</Typography>
+                  </Box>
+                  <Typography sx={{ fontWeight: 600, fontSize: fontSizes.md, color: colors.text.secondary, mb: 0.5, lineHeight: 1.5 }}>{company.companyName}</Typography>
+                  <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>{company.branchName}</Typography>
+                </Box>
+              );
+            })}
+          </Box>
+        ) : (
+          <Box sx={{ p: 4, textAlign: 'center', color: colors.text.light }}>
+            {totalCount > 0 ? '条件に一致する企業がありません' : '着手企業がありません'}
+          </Box>
+        )}
+      </Box>
+      {/* フッター（ページネーション） */}
+      <Box sx={{ backgroundColor: colors.text.white, borderTop: `1px solid ${colors.border.main}`, px: 2 }}>
+        <CustomPagination
+          page={page}
+          pageSize={pageSize}
+          rowCount={filteredCount}
+          onPageChange={onPageChange}
+          onPageSizeChange={() => {}}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/DocumentSection.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/DocumentSection.tsx
@@ -1,0 +1,171 @@
+import { Box, Typography, Button, Accordion, AccordionSummary, AccordionDetails, CircularProgress } from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  OpenInNew as OpenInNewIcon,
+  TextSnippet as TextSnippetIcon,
+} from '@mui/icons-material';
+import { getDocumentTypeConfig, getFileFormatConfig } from '../../constants/documentType';
+import { colors, fontSizes, iconStyles, borderRadius } from '../../constants/styles';
+import type { DocumentOcr } from '../../types';
+
+type PreviewState = { url?: string; loading: boolean; error?: string };
+
+interface DocumentSectionProps {
+  documents: DocumentOcr[];
+  documentPreviewState: Record<string, PreviewState>;
+  loadPdfPreview: (documentId: number, options?: { force?: boolean }) => void;
+}
+
+export function DocumentSection({
+  documents,
+  documentPreviewState,
+  loadPdfPreview,
+}: DocumentSectionProps) {
+  return (
+    <Box sx={{ p: 2.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      {documents.map((doc: DocumentOcr, index: number) => {
+        const typeConfig = getDocumentTypeConfig(doc.type || 'other');
+        const formatConfig = getFileFormatConfig(doc.fileFormat);
+        const isPdfDocument = doc.fileFormat && doc.fileFormat.toLowerCase() === 'pdf';
+        const docId = doc.id;
+        const docKey = String(docId);
+        const previewState = documentPreviewState[docKey];
+        const isPreviewLoading = previewState?.loading;
+        const previewUrl = previewState?.url;
+        const previewError = previewState?.error;
+        return (
+          <Accordion
+            key={doc.id}
+            defaultExpanded={index === 0}
+            onChange={(_, expanded) => {
+              if (expanded && isPdfDocument) {
+                loadPdfPreview(docId);
+              }
+            }}
+            sx={{
+              backgroundColor: colors.text.white,
+              border: `1px solid ${colors.border.main}`,
+              borderRadius: `${borderRadius.xs} !important`,
+              boxShadow: 'none',
+              '&:before': { display: 'none' },
+              '&.Mui-expanded': { margin: 0 },
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon sx={{ color: colors.text.muted }} />}
+              sx={{
+                px: 2.5,
+                py: 0.5,
+                minHeight: 48,
+                borderBottom: `1px solid ${colors.border.main}`,
+                '& .MuiAccordionSummary-content': { alignItems: 'center', gap: 1.5, my: 1 },
+              }}
+            >
+              <TextSnippetIcon sx={{ ...iconStyles.medium, color: colors.text.light }} />
+              <Typography sx={{ fontSize: fontSizes.md, fontWeight: 600, color: colors.text.secondary }}>{doc.title}</Typography>
+              <Typography sx={{ fontSize: fontSizes.md, fontWeight: 600, color: typeConfig.color, backgroundColor: typeConfig.bgColor, px: 1, py: 0.25, borderRadius: '2px' }}>
+                {typeConfig.label}
+              </Typography>
+              {doc.url && (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  endIcon={<OpenInNewIcon sx={iconStyles.small} />}
+                  component="a"
+                  href={doc.url}
+                  target="_blank"
+                  onClick={(e) => e.stopPropagation()}
+                  sx={{ borderRadius: borderRadius.xs, borderColor: formatConfig.color, color: formatConfig.color, fontWeight: 500, fontSize: fontSizes.xs, textTransform: 'none', py: 0.25, px: 1 }}
+                >
+                  {formatConfig.label}
+                </Button>
+              )}
+              {doc.pageCount && <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light, ml: 'auto', mr: 1 }}>{doc.pageCount}ページ</Typography>}
+            </AccordionSummary>
+            <AccordionDetails sx={{ p: 2.5, backgroundColor: colors.background.paper, display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {isPdfDocument && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Typography sx={{ fontSize: fontSizes.sm, fontWeight: 600, color: colors.text.secondary }}>PDFプレビュー</Typography>
+                  {isPreviewLoading ? (
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px dashed ${colors.border.main}`, borderRadius: borderRadius.xs, height: 400, backgroundColor: colors.text.white }}>
+                      <CircularProgress size={28} sx={{ color: colors.primary.main, mr: 1.5 }} />
+                      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>プレビューを読み込み中です...</Typography>
+                    </Box>
+                  ) : previewError ? (
+                    <Box sx={{ border: `1px solid ${colors.status.error.light}`, borderRadius: borderRadius.xs, p: 2, backgroundColor: '#fff5f5', display: 'flex', flexDirection: 'column', gap: 1 }}>
+                      <Typography sx={{ fontSize: fontSizes.md, fontWeight: 600, color: colors.status.error.main }}>
+                        プレビューの読み込みに失敗しました
+                      </Typography>
+                      <Typography sx={{ fontSize: fontSizes.sm, color: colors.text.light }}>
+                        {previewError}
+                      </Typography>
+                      <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                        ファイルが存在しないか、アクセス権限が不足している可能性があります。
+                      </Typography>
+                      <Box sx={{ display: 'flex', gap: 1 }}>
+                        <Button
+                          variant="outlined"
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            loadPdfPreview(docId, { force: true });
+                          }}
+                          sx={{ borderRadius: borderRadius.xs }}
+                        >
+                          再読み込み
+                        </Button>
+                        {doc.url && (
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              window.open(doc.url, '_blank');
+                            }}
+                            sx={{ borderRadius: borderRadius.xs }}
+                          >
+                            元のURLを開く
+                          </Button>
+                        )}
+                      </Box>
+                    </Box>
+                  ) : previewUrl ? (
+                    <Box
+                      component="iframe"
+                      title={`${doc.title} プレビュー`}
+                      src={previewUrl}
+                      sx={{
+                        width: '100%',
+                        height: 420,
+                        border: `1px solid ${colors.border.main}`,
+                        borderRadius: borderRadius.xs,
+                        backgroundColor: colors.text.white,
+                      }}
+                    />
+                  ) : (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        loadPdfPreview(docId);
+                      }}
+                      sx={{ alignSelf: 'flex-start', borderRadius: borderRadius.xs }}
+                    >
+                      PDFプレビューを読み込む
+                    </Button>
+                  )}
+                </Box>
+              )}
+              <Box sx={{ border: `1px solid ${colors.border.main}`, borderRadius: borderRadius.xs, maxHeight: 420, overflow: 'auto', backgroundColor: colors.text.white, p: 2 }}>
+                <Typography component="pre" sx={{ fontSize: fontSizes.md, color: colors.text.muted, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'inherit', margin: 0, lineHeight: 1.8 }}>
+                  {doc.content || '文字起こしデータがありません'}
+                </Typography>
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/RequirementSection.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/RequirementSection.tsx
@@ -1,0 +1,251 @@
+import { Box, Typography, Button, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import {
+  AccountBalance as OrdererIcon,
+  LocationOn as LocationIcon,
+  Phone as PhoneIcon,
+  Email as EmailIcon,
+  Person as PersonIcon,
+  Print as FaxIcon,
+  OpenInNew as OpenInNewIcon,
+  Category as CategoryIcon,
+  CurrencyYen as CurrencyYenIcon,
+  ExpandMore as ExpandMoreIcon,
+  Gavel as BidTypeIcon,
+} from '@mui/icons-material';
+import { bidTypeConfig } from '../../data';
+import { getDocumentTypeConfig, getFileFormatConfig } from '../../constants/documentType';
+import { colors, fontSizes, iconStyles, borderRadius } from '../../constants/styles';
+import { formatAmountInManYen } from '../../utils';
+import { resolveAnnouncementStatus, resolveBidType } from './AnnouncementHeader';
+import type { AnnouncementDetail } from './AnnouncementHeader';
+import type { ProgressingCompany } from './CompetingCompaniesSection';
+import type { DocumentOcr } from '../../types';
+
+function InfoRow({ label, value, icon }: { label: string; value: string; icon?: React.ReactNode }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1.25, borderBottom: `1px solid ${colors.background.hover}`, '&:last-child': { borderBottom: 'none' } }}>
+      {icon && <Box sx={{ mt: 0.25 }}>{icon}</Box>}
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, fontWeight: 500, minWidth: 90 }}>{label}</Typography>
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.secondary, fontWeight: 500, flex: 1 }}>{value}</Typography>
+    </Box>
+  );
+}
+
+interface RequirementSectionProps {
+  announcement: AnnouncementDetail;
+  progressingCompanies: ProgressingCompany[];
+  onNavigate: (path: string) => void;
+}
+
+export function RequirementSection({ announcement, progressingCompanies, onNavigate }: RequirementSectionProps) {
+  const announcementStatus = resolveAnnouncementStatus(announcement.status as string | undefined);
+
+  const scheduleItems = [
+    { label: '公告日', date: announcement.publishDate },
+    { label: '説明書交付開始', date: announcement.explanationStartDate },
+    { label: '説明書交付終了', date: announcement.explanationEndDate },
+    { label: '申請受付開始', date: announcement.applicationStartDate },
+    { label: '申請受付終了', date: announcement.applicationEndDate },
+    { label: '入札開始', date: announcement.bidStartDate },
+    { label: '入札締切', date: announcement.bidEndDate, highlight: true },
+  ];
+
+  const sortedCompetitors = [...(announcement.competingCompanies || [])].sort((a, b) => {
+    if (a.isWinner && !b.isWinner) return -1;
+    if (!a.isWinner && b.isWinner) return 1;
+    return 0;
+  });
+
+  const formatBidAmount = (amount: number | null | undefined) => {
+    if (amount === null || amount === undefined) return '-';
+    return `${(amount / 10000).toLocaleString()}万`;
+  };
+
+  return (
+    <Box sx={{ p: 2.5 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
+        {/* 左カラム */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {/* 案件情報 */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>案件情報</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              <InfoRow label="発注機関" value={announcement.organization} icon={<OrdererIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="工種" value={announcement.category} icon={<CategoryIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="入札形式" value={bidTypeConfig[resolveBidType(announcement.bidType)].label} icon={<BidTypeIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="履行場所" value={announcement.workLocation} icon={<LocationIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="予想金額" value={formatAmountInManYen(announcement.estimatedAmountMin, announcement.estimatedAmountMax)} icon={<CurrencyYenIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+            </AccordionDetails>
+          </Accordion>
+
+          {/* 担当部署 */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>担当部署</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              <InfoRow label="部署名" value={announcement.department.name} icon={<OrdererIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="担当者" value={announcement.department.contactPerson} icon={<PersonIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="住所" value={`〒${announcement.department.postalCode} ${announcement.department.address}`} icon={<LocationIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="電話" value={announcement.department.phone} icon={<PhoneIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="FAX" value={announcement.department.fax} icon={<FaxIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <InfoRow label="メール" value={announcement.department.email} icon={<EmailIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+            </AccordionDetails>
+          </Accordion>
+
+          {/* 資料リンク */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>資料リンク</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              {announcement.documents && announcement.documents.length > 0 ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {announcement.documents.map((doc: DocumentOcr) => {
+                    const typeConfig = getDocumentTypeConfig(doc.type || 'other');
+                    const formatConfig = getFileFormatConfig(doc.fileFormat);
+                    return (
+                      <Button
+                        key={doc.id}
+                        variant="outlined"
+                        size="small"
+                        endIcon={<OpenInNewIcon sx={iconStyles.small} />}
+                        component="a"
+                        href={doc.url || '#'}
+                        target="_blank"
+                        disabled={!doc.url}
+                        sx={{ borderRadius: borderRadius.xs, borderColor: formatConfig.color, color: doc.url ? formatConfig.color : colors.text.light, fontWeight: 500, fontSize: fontSizes.md, textTransform: 'none', justifyContent: 'space-between' }}
+                      >
+                        {typeConfig.label}（{formatConfig.label}）
+                      </Button>
+                    );
+                  })}
+                </Box>
+              ) : (
+                <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+                  資料がありません
+                </Typography>
+              )}
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+
+        {/* 右カラム */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {/* 落札情報 */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: announcementStatus === 'closed' && announcement.actualAmount ? '1px solid #a7f3d0' : `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: announcementStatus === 'closed' && announcement.actualAmount ? colors.status.success.main : colors.primary.main }}>落札情報</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap', mb: (announcement.competingCompanies?.length || progressingCompanies.length > 0) ? 2 : 0 }}>
+                <Box>
+                  <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, mb: 0.25 }}>見積予想金額</Typography>
+                  <Typography sx={{ fontSize: fontSizes.lg, fontWeight: 700, color: colors.text.secondary }}>
+                    {formatAmountInManYen(announcement.estimatedAmountMin, announcement.estimatedAmountMax)}
+                  </Typography>
+                </Box>
+                {announcementStatus === 'closed' && announcement.actualAmount && (
+                  <>
+                    <Box>
+                      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, mb: 0.25 }}>落札金額</Typography>
+                      <Typography sx={{ fontSize: fontSizes.lg, fontWeight: 700, color: colors.status.success.main }}>
+                        {(announcement.actualAmount / 10000).toLocaleString()}万円
+                      </Typography>
+                    </Box>
+                    {announcement.winningCompanyName && (
+                      <Box>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, mb: 0.25 }}>落札企業</Typography>
+                        <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.text.secondary }}>
+                          {announcement.winningCompanyName}
+                        </Typography>
+                      </Box>
+                    )}
+                  </>
+                )}
+              </Box>
+              {/* 競争参加企業 */}
+              {(announcement.competingCompanies?.length || progressingCompanies.length > 0) && (
+                <Box sx={{ pt: 2, borderTop: `1px solid ${colors.border.light}` }}>
+                  <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, mb: 1.5 }}>
+                    競争参加企業 ({sortedCompetitors.length + progressingCompanies.length}社)
+                  </Typography>
+                  {/* ヘッダー */}
+                  <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 110px 110px 110px', gap: 1, mb: 1, pb: 1, borderBottom: `1px solid ${colors.border.main}` }}>
+                    <Typography sx={{ fontSize: fontSizes.sm, color: colors.text.light, fontWeight: 500 }}>企業名</Typography>
+                    <Typography sx={{ fontSize: fontSizes.sm, color: colors.text.light, fontWeight: 500, textAlign: 'right' }}>1回目</Typography>
+                    <Typography sx={{ fontSize: fontSizes.sm, color: colors.text.light, fontWeight: 500, textAlign: 'right' }}>2回目</Typography>
+                    <Typography sx={{ fontSize: fontSizes.sm, color: colors.text.light, fontWeight: 500, textAlign: 'right' }}>3回目</Typography>
+                  </Box>
+                  {/* 企業一覧 */}
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                    {sortedCompetitors.map((company, idx) => (
+                      <Box key={idx} sx={{ display: 'grid', gridTemplateColumns: '1fr 110px 110px 110px', gap: 1, alignItems: 'center', py: 0.5 }}>
+                        <Typography sx={{ fontSize: fontSizes.md, fontWeight: company.isWinner ? 600 : 400, color: company.isWinner ? colors.status.success.main : colors.text.secondary }}>
+                          {company.name}
+                        </Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          {formatBidAmount(company.bidAmounts?.[0])}
+                        </Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          {formatBidAmount(company.bidAmounts?.[1])}
+                        </Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: company.isWinner ? colors.status.success.main : colors.text.muted, fontWeight: company.isWinner ? 600 : 400, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                          {formatBidAmount(company.bidAmounts?.[2])}
+                        </Typography>
+                      </Box>
+                    ))}
+                    {progressingCompanies.map((company) => (
+                      <Box
+                        key={`${company.companyId}-${company.branchId}`}
+                        onClick={() => onNavigate(`/detail/${company.evaluationId}`)}
+                        sx={{ display: 'grid', gridTemplateColumns: '1fr 110px 110px 110px', gap: 1, alignItems: 'center', py: 0.5, cursor: 'pointer', '&:hover': { backgroundColor: colors.background.hover, mx: -1, px: 1, borderRadius: borderRadius.xs } }}
+                      >
+                        <Typography sx={{ fontSize: fontSizes.md, fontWeight: 500, color: colors.accent.blue }}>{company.companyName}</Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light, textAlign: 'right' }}>-</Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light, textAlign: 'right' }}>-</Typography>
+                        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light, textAlign: 'right' }}>-</Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Box>
+              )}
+            </AccordionDetails>
+          </Accordion>
+
+          {/* スケジュール */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>スケジュール</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 1, pb: 0, px: 0 }}>
+              {scheduleItems.map((item, index) => (
+                <Box
+                  key={item.label}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    px: 2.5,
+                    py: 1.25,
+                    borderBottom: index < scheduleItems.length - 1 ? `1px solid ${colors.border.light}` : 'none',
+                    backgroundColor: item.highlight ? colors.status.info.bg : 'transparent',
+                  }}
+                >
+                  <Typography sx={{ fontSize: fontSizes.md, color: item.highlight ? colors.primary.main : colors.text.muted, fontWeight: item.highlight ? 600 : 400 }}>
+                    {item.label}
+                  </Typography>
+                  <Typography sx={{ fontSize: fontSizes.md, color: item.highlight ? colors.primary.main : colors.text.secondary, fontWeight: item.highlight ? 700 : 500 }}>
+                    {item.date}
+                  </Typography>
+                </Box>
+              ))}
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/index.ts
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/announcement/index.ts
@@ -1,0 +1,9 @@
+export { AnnouncementFilterModal } from './AnnouncementFilterModal';
+export type { AnnouncementFilterState } from './AnnouncementFilterModal';
+export { AnnouncementDisplayConditionsPanel } from './AnnouncementDisplayConditionsPanel';
+export { AnnouncementHeader, AnnouncementTabs, resolveAnnouncementStatus, resolveBidType } from './AnnouncementHeader';
+export type { AnnouncementDetail } from './AnnouncementHeader';
+export { DocumentSection } from './DocumentSection';
+export { RequirementSection } from './RequirementSection';
+export { CompetingCompaniesSection } from './CompetingCompaniesSection';
+export type { ProgressingCompany } from './CompetingCompaniesSection';

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/common/ErrorBoundary.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,13 @@
+import { Component, ReactNode } from 'react';
+
+interface Props { children: ReactNode; fallback?: ReactNode; }
+interface State { hasError: boolean; }
+
+export class ErrorBoundary extends Component<Props, State> {
+  state = { hasError: false };
+  static getDerivedStateFromError() { return { hasError: true }; }
+  render() {
+    if (this.state.hasError) return this.props.fallback || <div>Something went wrong</div>;
+    return this.props.children;
+  }
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/common/index.ts
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/common/index.ts
@@ -1,0 +1,45 @@
+export { ErrorBoundary } from './ErrorBoundary';
+export { FilterOptionButton } from './FilterOptionButton';
+export { SelectAllButton } from './SelectAllButton';
+export { CollapsibleSection } from './CollapsibleSection';
+export { CollapsiblePanel } from './CollapsiblePanel';
+export { IconText } from './IconText';
+export { InfoRow } from './InfoRow';
+export { AddressText } from './AddressText';
+export { EstimateDisplay } from './EstimateDisplay';
+export { FloatingBackButton, ScrollToTopButton, FloatingWorkflowMenu } from './FloatingButtons';
+export { ConfigChip } from './ConfigChip';
+
+// 詳細ページ用コンポーネント
+export {
+  DetailInfoRow,
+  StatCard,
+  ScheduleItem,
+  NotFoundView,
+  DetailPageHeader,
+  SectionCard,
+} from './DetailComponents';
+
+// ステータスチップ
+export {
+  EvaluationStatusChip,
+  WorkStatusChip,
+  PriorityChip,
+} from './StatusChips';
+
+export type { CollapsibleSectionProps } from './CollapsibleSection';
+export type { CollapsiblePanelProps } from './CollapsiblePanel';
+export type { IconTextProps } from './IconText';
+export type { InfoRowProps } from './InfoRow';
+export type { AddressTextProps } from './AddressText';
+export type { EstimateDisplayProps } from './EstimateDisplay';
+export type { FloatingBackButtonProps, FloatingWorkflowMenuProps, WorkflowMenuItem } from './FloatingButtons';
+export type { ChipConfig, ChipVariant } from './ConfigChip';
+export type {
+  DetailInfoRowProps,
+  StatCardProps,
+  ScheduleItemProps,
+  NotFoundViewProps,
+  DetailPageHeaderProps,
+  SectionCardProps,
+} from './DetailComponents';

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerBasicInfo.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerBasicInfo.tsx
@@ -1,0 +1,97 @@
+import { Box, Typography, Chip, Link, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import {
+  Phone as PhoneIcon,
+  LocationOn as LocationIcon,
+  Email as EmailIcon,
+  Print as FaxIcon,
+  Language as LanguageIcon,
+  Person as PersonIcon,
+  CalendarMonth as CalendarIcon,
+  AccountBalance as AccountBalanceIcon,
+  People as PeopleIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material';
+import { colors, fontSizes, chipStyles, iconStyles, borderRadius } from '../../constants/styles';
+
+function InfoRow({ label, value, icon }: { label: string; value: React.ReactNode; icon?: React.ReactNode }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1.25, borderBottom: `1px solid ${colors.background.hover}`, '&:last-child': { borderBottom: 'none' } }}>
+      {icon && <Box sx={{ mt: 0.25 }}>{icon}</Box>}
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, fontWeight: 500, minWidth: 80 }}>{label}</Typography>
+      <Typography component="div" sx={{ fontSize: fontSizes.md, color: colors.text.secondary, fontWeight: 500, flex: 1 }}>{value}</Typography>
+    </Box>
+  );
+}
+
+interface PartnerBasicInfoProps {
+  partner: any;
+}
+
+export function PartnerBasicInfo({ partner }: PartnerBasicInfoProps) {
+  const capitalDisplay = partner.capital != null
+    ? `${(partner.capital / 100000000).toLocaleString()}億円`
+    : '未設定';
+  const employeeDisplay = partner.employeeCount != null
+    ? `${partner.employeeCount.toLocaleString()}名`
+    : '未設定';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {/* 会社情報 */}
+      <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>会社情報</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+          <InfoRow label="住所" value={`〒${partner.postalCode} ${partner.address}`} icon={<LocationIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="電話番号" value={partner.phone} icon={<PhoneIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="FAX" value={partner.fax} icon={<FaxIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="メール" value={<Link href={`mailto:${partner.email}`} sx={{ color: colors.accent.blue }}>{partner.email}</Link>} icon={<EmailIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          {partner.url && <InfoRow label="HP" value={<Link href={partner.url} target="_blank" rel="noopener noreferrer" sx={{ color: colors.accent.blue }}>{partner.url}</Link>} icon={<LanguageIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />}
+          <InfoRow label="代表者" value={partner.representative} icon={<PersonIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="設立" value={`${partner.established}年`} icon={<CalendarIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="資本金" value={capitalDisplay} icon={<AccountBalanceIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+          <InfoRow label="従業員数" value={employeeDisplay} icon={<PeopleIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+        </AccordionDetails>
+      </Accordion>
+
+      {/* 拠点一覧 */}
+      <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>拠点一覧 ({partner.branches.length})</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+          {partner.branches.map((branch: any, index: number) => (
+            <Box key={index} sx={{ py: 1.25, borderBottom: index < partner.branches.length - 1 ? `1px solid ${colors.border.light}` : 'none' }}>
+              <Typography sx={{ fontWeight: 600, fontSize: fontSizes.md, color: colors.text.secondary }}>{branch.name}</Typography>
+              <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>{branch.address}</Typography>
+            </Box>
+          ))}
+        </AccordionDetails>
+      </Accordion>
+
+      {/* カテゴリ */}
+      <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>カテゴリ ({partner.categories.length})</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+          <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+            {partner.categories.map((category: string) => (
+              <Chip
+                key={category}
+                label={category}
+                size="small"
+                sx={{
+                  ...chipStyles.small,
+                  backgroundColor: colors.status.info.bg,
+                  color: colors.accent.blue,
+                }}
+              />
+            ))}
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerHistory.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerHistory.tsx
@@ -1,0 +1,157 @@
+import { Box, Typography } from '@mui/material';
+import { bidTypeConfig } from '../../data';
+import { colors, fontSizes, borderRadius } from '../../constants/styles';
+import { workStatusConfig } from '../../constants/workStatus';
+import { evaluationStatusConfig } from '../../constants/status';
+import { priorityLabels, priorityColors } from '../../constants/priority';
+import { CustomPagination } from '../bid';
+import type { PastProject } from '../../types/partner';
+import type { CompanyPriority } from '../../types';
+
+function getDeadlineColor(deadline: string): { textColor: string } {
+  const deadlineDate = new Date(deadline);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  deadlineDate.setHours(0, 0, 0, 0);
+
+  const diffTime = deadlineDate.getTime() - today.getTime();
+  const days = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (days < 0) return { textColor: colors.text.muted };
+  if (days === 0) return { textColor: colors.status.error.main };
+  if (days <= 3) return { textColor: colors.status.error.main };
+  if (days <= 7) return { textColor: colors.status.warning.main };
+  if (days <= 14) return { textColor: colors.accent.yellowDark };
+  return { textColor: colors.status.success.main };
+}
+
+interface PartnerHistoryProps {
+  projects: PastProject[];
+  page: number;
+  pageSize: number;
+  filteredCount: number;
+  onPageChange: (page: number) => void;
+  onNavigate: (path: string) => void;
+}
+
+export function PartnerHistory({
+  projects,
+  page,
+  pageSize,
+  filteredCount,
+  onPageChange,
+  onNavigate,
+}: PartnerHistoryProps) {
+  return (
+    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {/* スクロール可能なカードグリッド */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2.5 }}>
+        {projects.length > 0 ? (
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 1.5 }}>
+            {projects.map((project) => {
+              const wsConfig = workStatusConfig[project.workStatus];
+              const evalConfig = evaluationStatusConfig[project.evaluationStatus];
+              const priorityValue = project.priority as CompanyPriority | null;
+              const priorityColor = priorityValue
+                ? priorityColors[priorityValue]
+                : { color: colors.text.light, bgColor: colors.background.alt, borderColor: colors.border.main, gradient: colors.text.light };
+              const priorityLabel = priorityValue
+                ? priorityLabels[priorityValue]
+                : '優先度: 未設定';
+              const bidType = project.bidType ? bidTypeConfig[project.bidType] : null;
+              const deadlineColor = getDeadlineColor(project.deadline);
+              return (
+                <Box
+                  key={project.announcementId}
+                  onClick={() => onNavigate(`/detail/${project.evaluationId}`)}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    p: 2,
+                    backgroundColor: colors.text.white,
+                    border: `1px solid ${colors.border.main}`,
+                    borderRadius: borderRadius.xs,
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    '&:hover': { borderColor: 'rgba(59, 130, 246, 0.4)', boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)' },
+                    '&::before': {
+                      content: '""',
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: '3px',
+                      backgroundColor: wsConfig.color,
+                      borderRadius: `${borderRadius.xs} 0 0 ${borderRadius.xs}`,
+                    },
+                  }}
+                >
+                  {/* 1行目: No. + 着手ステータス + 参加可否 + 優先度 + 入札形式 */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
+                    <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light }}>
+                      No. {String(project.announcementNo).padStart(8, '0')}
+                    </Typography>
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: wsConfig.color }}>
+                      {wsConfig.label}
+                    </Typography>
+                    <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: evalConfig.color }}>
+                      {evalConfig.label}
+                    </Typography>
+                    <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
+                    <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: priorityColor.color }}>
+                      {priorityLabel}
+                    </Typography>
+                    {bidType && (
+                      <>
+                        <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
+                        <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                          {bidType.label}
+                        </Typography>
+                      </>
+                    )}
+                  </Box>
+                  {/* 2行目: タイトル */}
+                  <Typography sx={{ fontWeight: 600, fontSize: fontSizes.md, color: colors.text.secondary, lineHeight: 1.5, mb: 1, flex: 1, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                    {project.announcementTitle}
+                  </Typography>
+                  {/* 3行目: 支店名 */}
+                  <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted, mb: 0.75 }}>
+                    {project.branchName}
+                  </Typography>
+                  {/* 4行目: 発注機関・都道府県・種別 */}
+                  <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light, mb: 0.75 }}>
+                    {project.organization}{project.prefecture && `・${project.prefecture}`}・{project.category}
+                  </Typography>
+                  {/* 5行目: 判定日・締切日 */}
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                      判定日 {project.evaluatedAt}
+                    </Typography>
+                    <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>/</Typography>
+                    <Typography sx={{ fontSize: fontSizes.xs, color: deadlineColor.textColor, fontWeight: 500 }}>
+                      締切日 {project.deadline}
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        ) : (
+          <Box sx={{ p: 4, textAlign: 'center', color: colors.text.light }}>該当する対応案件がありません</Box>
+        )}
+      </Box>
+      {/* フッター（ページネーション） */}
+      <Box sx={{ backgroundColor: colors.text.white, borderTop: `1px solid ${colors.border.main}`, px: 2 }}>
+        <CustomPagination
+          page={page}
+          pageSize={pageSize}
+          rowCount={filteredCount}
+          onPageChange={onPageChange}
+          onPageSizeChange={() => {}}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerQualifications.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/PartnerQualifications.tsx
@@ -1,0 +1,109 @@
+import { Box, Typography, Rating, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { colors, fontSizes, borderRadius } from '../../constants/styles';
+
+interface PartnerQualificationsProps {
+  partner: any;
+}
+
+export function PartnerQualifications({ partner }: PartnerQualificationsProps) {
+  const ratingValue = partner.rating ?? 0;
+  const surveyDisplay = partner.surveyCount != null ? `${partner.surveyCount}回` : '未設定';
+  const resultDisplay = partner.resultCount != null ? `${partner.resultCount}件` : '未設定';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {/* 実績サマリー */}
+      <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>実績サマリー</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 2, pb: 2, px: 0, backgroundColor: colors.background.hover }}>
+          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr auto 1fr', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+              <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>評価</Typography>
+              <Rating value={ratingValue} max={3} precision={0.5} readOnly size="small" />
+            </Box>
+            <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+              <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>現地調査</Typography>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{surveyDisplay}</Typography>
+            </Box>
+            <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+              <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>実績数</Typography>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{resultDisplay}</Typography>
+            </Box>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* 競争参加資格 */}
+      <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>競争参加資格</Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+          {/* 全省庁統一資格 */}
+          <Typography sx={{ fontSize: fontSizes.sm, fontWeight: 600, color: colors.text.muted, mb: 1.5, textTransform: 'uppercase', letterSpacing: '0.03em' }}>全省庁統一資格</Typography>
+          {partner.qualifications.unified.length === 0 ? (
+            <Typography sx={{ color: colors.text.light, fontSize: fontSizes.sm, mb: 2.5 }}>登録なし</Typography>
+          ) : (
+            <Box sx={{ mb: 2.5, border: `1px solid ${colors.border.main}`, borderRadius: borderRadius.xs, overflow: 'hidden' }}>
+              {/* テーブルヘッダー */}
+              <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 100px 80px 70px', backgroundColor: colors.background.alt, borderBottom: `1px solid ${colors.border.main}` }}>
+                <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted }}>大分類</Typography>
+                <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted }}>種別</Typography>
+                <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted }}>地域</Typography>
+                <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'right' }}>点数</Typography>
+                <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'center' }}>等級</Typography>
+              </Box>
+              {/* テーブルボディ */}
+              {partner.qualifications.unified.map((q: any, idx: number) => (
+                <Box key={idx} sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 100px 80px 70px', borderBottom: idx < partner.qualifications.unified.length - 1 ? `1px solid ${colors.border.light}` : 'none', '&:hover': { backgroundColor: 'rgba(0,0,0,0.02)' } }}>
+                  <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{q.mainCategory}</Typography>
+                  <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{q.category}</Typography>
+                  <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.muted }}>{q.region}</Typography>
+                  <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary, fontWeight: 600, textAlign: 'right' }}>{q.value}</Typography>
+                  <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.accent.blue, fontWeight: 600, textAlign: 'center' }}>{q.grade}</Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {/* 発注者別資格 */}
+          <Typography sx={{ fontSize: fontSizes.sm, fontWeight: 600, color: colors.text.muted, mb: 1.5, textTransform: 'uppercase', letterSpacing: '0.03em' }}>発注者別資格</Typography>
+          {partner.qualifications.orderers.length === 0 ? (
+            <Typography sx={{ color: colors.text.light, fontSize: fontSizes.sm }}>登録なし</Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {partner.qualifications.orderers.map((orderer: any, idx: number) => (
+                <Box key={idx}>
+                  <Typography sx={{ fontSize: fontSizes.sm, fontWeight: 600, color: colors.text.secondary, mb: 1, pl: 1.5, borderLeft: `3px solid ${colors.accent.blue}` }}>{orderer.ordererName}</Typography>
+                  <Box sx={{ border: `1px solid ${colors.border.main}`, borderRadius: borderRadius.xs, overflow: 'hidden' }}>
+                    {/* テーブルヘッダー */}
+                    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 120px 80px 70px', backgroundColor: colors.background.alt, borderBottom: `1px solid ${colors.border.main}` }}>
+                      <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted }}>種別</Typography>
+                      <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted }}>地域</Typography>
+                      <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'right' }}>点数</Typography>
+                      <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'center' }}>等級</Typography>
+                    </Box>
+                    {/* テーブルボディ */}
+                    {orderer.items.map((item: any, itemIdx: number) => (
+                      <Box key={itemIdx} sx={{ display: 'grid', gridTemplateColumns: '1fr 120px 80px 70px', borderBottom: itemIdx < orderer.items.length - 1 ? `1px solid ${colors.border.light}` : 'none', '&:hover': { backgroundColor: 'rgba(0,0,0,0.02)' } }}>
+                        <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{item.category}</Typography>
+                        <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.muted }}>{item.region}</Typography>
+                        <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary, fontWeight: 600, textAlign: 'right' }}>{item.value}</Typography>
+                        <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.accent.blue, fontWeight: 600, textAlign: 'center' }}>{item.grade}</Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/index.ts
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/components/partner/index.ts
@@ -1,0 +1,6 @@
+export { PartnerFilterModal } from './PartnerFilterModal';
+export type { PartnerFilterState } from './PartnerFilterModal';
+export { PartnerDisplayConditionsPanel } from './PartnerDisplayConditionsPanel';
+export { PartnerBasicInfo } from './PartnerBasicInfo';
+export { PartnerQualifications } from './PartnerQualifications';
+export { PartnerHistory } from './PartnerHistory';

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/pages/AnnouncementDetailPage.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/pages/AnnouncementDetailPage.tsx
@@ -1,0 +1,1896 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { Box, Typography, Button, Paper, TextField, InputAdornment, IconButton } from '@mui/material';
+import {
+  Search as SearchIcon,
+  SwapVert as SortIcon,
+  FilterAlt as FilterIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import {
+  announcementStatusConfig,
+  bidTypeConfig,
+} from '../data';
+import { colors, pageStyles, fontSizes, iconStyles, borderRadius, rightPanelColors } from '../constants/styles';
+import { evaluationStatusConfig } from '../constants/status';
+import { priorityLabels, priorityColors } from '../constants/priority';
+import { categories } from '../constants/categories';
+import { bidTypes } from '../constants/bidType';
+import { prefecturesByRegion } from '../constants/prefectures';
+import { organizationGroupsByRegion, getOrganizationGroup } from '../constants/organizations';
+import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
+import { CustomPagination } from '../components/bid';
+import { RightSidePanel } from '../components/layout';
+import {
+  AnnouncementHeader,
+  AnnouncementTabs,
+  resolveAnnouncementStatus,
+  resolveBidType,
+  DocumentSection,
+  RequirementSection,
+  CompetingCompaniesSection,
+} from '../components/announcement';
+import type { AnnouncementDetail } from '../components/announcement';
+import type { ProgressingCompany } from '../components/announcement';
+import { useSidebar } from '../contexts/SidebarContext';
+import type { BidType, AnnouncementStatus } from '../types/announcement';
+import type { EvaluationStatus, WorkStatus, CompanyPriority, DocumentOcr } from '../types';
+import { getApiUrl } from '../config/api';
+
+// 関連案件用ソートオプション
+type SortOption = 'deadline_asc' | 'deadline_desc' | 'publish_asc' | 'publish_desc' | 'status_asc' | 'status_desc' | 'prefecture_asc' | 'prefecture_desc';
+
+// 着手企業用ソートオプション
+type CompanySortOption = 'priority_asc' | 'priority_desc' | 'workStatus_asc' | 'workStatus_desc' | 'company_asc' | 'company_desc' | 'evaluationStatus_asc' | 'evaluationStatus_desc';
+
+type PreviewState = { url?: string; loading: boolean; error?: string };
+
+// ソートフィールド定義
+const SORT_FIELDS = [
+  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
+  { field: 'status', label: 'ステータス', ascLabel: '公告中→終了', descLabel: '終了→公告中' },
+  { field: 'publish', label: '公告日', ascLabel: '古い', descLabel: '新しい' },
+  { field: 'prefecture', label: '都道府県', ascLabel: '北→南', descLabel: '南→北' },
+] as const;
+
+// フィルタータブ定義
+const FILTER_TABS = [
+  { id: 'status', label: 'ステータス' },
+  { id: 'bidType', label: '入札方式' },
+  { id: 'category', label: '種別' },
+  { id: 'prefecture', label: '都道府県' },
+  { id: 'organization', label: '発注機関' },
+] as const;
+
+// 着手企業用ソートフィールド定義
+const COMPANY_SORT_FIELDS = [
+  { field: 'priority', label: '優先度', ascLabel: '高い→低い', descLabel: '低い→高い' },
+  { field: 'evaluationStatus', label: '参加可否', ascLabel: '可→不可', descLabel: '不可→可' },
+  { field: 'workStatus', label: '着手状況', ascLabel: '着手中→完了', descLabel: '完了→着手中' },
+  { field: 'company', label: '企業名', ascLabel: 'あ→わ', descLabel: 'わ→あ' },
+] as const;
+
+// 着手企業用フィルタータブ定義
+const COMPANY_FILTER_TABS = [
+  { id: 'evaluationStatus', label: '参加可否' },
+  { id: 'workStatus', label: '着手状況' },
+  { id: 'priority', label: '優先度' },
+] as const;
+
+// フィルター状態の型
+interface RelatedFilterState {
+  statuses: AnnouncementStatus[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+  organizations: string[];
+}
+
+// ステータスオプション
+const STATUS_OPTIONS: AnnouncementStatus[] = ['upcoming', 'ongoing', 'awaiting_result', 'closed'];
+
+// ステータス順序（ソート用）
+const STATUS_ORDER: Record<AnnouncementStatus, number> = {
+  upcoming: 0,
+  ongoing: 1,
+  awaiting_result: 2,
+  closed: 3,
+};
+
+const getStatusOrderValue = (status?: string) => STATUS_ORDER[resolveAnnouncementStatus(status)] ?? 0;
+
+// 着手企業用フィルター状態の型
+interface CompanyFilterState {
+  evaluationStatuses: EvaluationStatus[];
+  workStatuses: ('in_progress' | 'completed')[];
+  priorities: (1 | 2 | 3 | 4 | 5)[];
+}
+
+// 参加可否オプション
+const EVALUATION_STATUS_OPTIONS: EvaluationStatus[] = ['all_met', 'other_only_unmet', 'unmet'];
+
+// 参加可否順序（ソート用）
+const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
+  all_met: 0,
+  other_only_unmet: 1,
+  unmet: 2,
+};
+
+// 着手状況オプション
+const WORK_STATUS_OPTIONS: Extract<WorkStatus, 'in_progress' | 'completed'>[] = ['in_progress', 'completed'];
+
+// 優先度オプション
+const PRIORITY_OPTIONS: CompanyPriority[] = [1, 2, 3, 4, 5];
+
+// 優先度順序（ソート用）
+const PRIORITY_ORDER: Record<CompanyPriority, number> = {
+  1: 1,
+  2: 2,
+  3: 3,
+  4: 4,
+  5: 5,
+};
+
+// 作業ステータス順序（ソート用）
+const WORK_STATUS_ORDER: Record<Extract<WorkStatus, 'in_progress' | 'completed'>, number> = {
+  in_progress: 0,
+  completed: 1,
+};
+
+const normalizePriority = (value: number): CompanyPriority => {
+  const rounded = Math.round(value);
+  return (PRIORITY_OPTIONS.includes(rounded as CompanyPriority) ? rounded : 1) as CompanyPriority;
+};
+
+const normalizeWorkStatus = (value: string): Extract<WorkStatus, 'in_progress' | 'completed'> => {
+  return value === 'completed' ? 'completed' : 'in_progress';
+};
+
+// フィルターボタン
+function FilterButton({
+  label,
+  selected,
+  onClick,
+  color,
+  bgColor,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  color?: string;
+  bgColor?: string;
+}) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        position: 'relative',
+        padding: '6px 12px',
+        paddingLeft: selected ? '14px' : '12px',
+        borderRadius: borderRadius.xs,
+        fontSize: fontSizes.xs,
+        fontWeight: selected ? 600 : 500,
+        cursor: 'pointer',
+        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
+        transition: 'all 0.2s ease',
+        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
+        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
+        overflow: 'hidden',
+        ...(selected && {
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: '3px',
+            backgroundColor: color || colors.accent.blue,
+          },
+        }),
+        '&:hover': {
+          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+          color: selected ? (color || colors.text.white) : rightPanelColors.text,
+          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
+        },
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+// 関連案件用表示条件パネル
+interface RelatedConditionsPanelProps {
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sortOption: SortOption | null;
+  onSortChange: (option: SortOption | null) => void;
+  filters: RelatedFilterState;
+  onFilterChange: (filters: RelatedFilterState) => void;
+  onClearAll: () => void;
+  activeTab?: 'sort' | 'filter';
+  onTabChange?: (tab: 'sort' | 'filter') => void;
+}
+
+function RelatedConditionsPanel({
+  searchQuery,
+  onSearchChange,
+  sortOption,
+  onSortChange,
+  filters,
+  onFilterChange,
+  onClearAll,
+  activeTab,
+  onTabChange,
+}: RelatedConditionsPanelProps) {
+  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
+  const [activeFilterTab, setActiveFilterTab] = useState(0);
+  const mainTab = activeTab ?? internalTab;
+  const setMainTab = (tab: 'sort' | 'filter') => {
+    setInternalTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // フィルター件数
+  const filterCounts = {
+    status: filters.statuses.length,
+    bidType: filters.bidTypes.length,
+    category: filters.categories.length,
+    prefecture: filters.prefectures.length,
+    organization: filters.organizations.length,
+  };
+  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
+  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
+
+  // トグル関数
+  const toggleStatus = (status: AnnouncementStatus) => {
+    const newStatuses = filters.statuses.includes(status)
+      ? filters.statuses.filter(s => s !== status)
+      : [...filters.statuses, status];
+    onFilterChange({ ...filters, statuses: newStatuses });
+  };
+
+  const toggleBidType = (bidType: string) => {
+    const newBidTypes = filters.bidTypes.includes(bidType)
+      ? filters.bidTypes.filter(b => b !== bidType)
+      : [...filters.bidTypes, bidType];
+    onFilterChange({ ...filters, bidTypes: newBidTypes });
+  };
+
+  const toggleCategory = (category: string) => {
+    const newCategories = filters.categories.includes(category)
+      ? filters.categories.filter(c => c !== category)
+      : [...filters.categories, category];
+    onFilterChange({ ...filters, categories: newCategories });
+  };
+
+  const togglePrefecture = (pref: string) => {
+    const newPrefs = filters.prefectures.includes(pref)
+      ? filters.prefectures.filter(p => p !== pref)
+      : [...filters.prefectures, pref];
+    onFilterChange({ ...filters, prefectures: newPrefs });
+  };
+
+  const togglePrefRegion = (regionItems: readonly string[]) => {
+    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
+      });
+    } else {
+      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
+      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
+    }
+  };
+
+  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const toggleOrganization = (org: string) => {
+    const newOrgs = filters.organizations.includes(org)
+      ? filters.organizations.filter(o => o !== org)
+      : [...filters.organizations, org];
+    onFilterChange({ ...filters, organizations: newOrgs });
+  };
+
+  const toggleOrgRegion = (regionItems: string[]) => {
+    const allSelected = regionItems.every(item => filters.organizations.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        organizations: filters.organizations.filter(o => !regionItems.includes(o)),
+      });
+    } else {
+      const newOrgs = new Set([...filters.organizations, ...regionItems]);
+      onFilterChange({ ...filters, organizations: Array.from(newOrgs) });
+    }
+  };
+
+  const getOrgRegionSelectionState = (regionItems: string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.organizations.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const sectionDivider = {
+    borderBottom: `1px solid ${rightPanelColors.border}`,
+    pb: 2.5,
+    mb: 2.5,
+  };
+
+  // フィルターコンテンツをレンダリング
+  const renderFilterContent = () => {
+    const tabId = FILTER_TABS[activeFilterTab].id;
+
+    switch (tabId) {
+      case 'status':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {STATUS_OPTIONS.map((status) => {
+              const config = announcementStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.statuses.includes(status)}
+                  onClick={() => toggleStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'bidType':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {bidTypes.map((bidType: BidType) => {
+              const config = bidTypeConfig[bidType];
+              return (
+                <FilterButton
+                  key={bidType}
+                  label={config.label}
+                  selected={filters.bidTypes.includes(bidType)}
+                  onClick={() => toggleBidType(bidType)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'category':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {categories.map((cat) => (
+              <FilterButton
+                key={cat}
+                label={cat}
+                selected={filters.categories.includes(cat)}
+                onClick={() => toggleCategory(cat)}
+              />
+            ))}
+          </Box>
+        );
+
+      case 'prefecture':
+        return (
+          <Box>
+            {prefecturesByRegion.map((region) => {
+              const selectionState = getPrefRegionSelectionState(region.prefectures);
+              return (
+                <Box key={region.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => togglePrefRegion(region.prefectures)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && '✓'}
+                      {selectionState === 'partial' && '−'}
+                    </span>
+                    {region.region}
+                    <span style={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                      ({region.prefectures.filter(p => filters.prefectures.includes(p)).length}/{region.prefectures.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {region.prefectures.map((pref) => (
+                      <FilterButton
+                        key={pref}
+                        label={pref}
+                        selected={filters.prefectures.includes(pref)}
+                        onClick={() => togglePrefecture(pref)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      case 'organization':
+        return (
+          <Box>
+            {organizationGroupsByRegion.map((region) => {
+              const selectionState = getOrgRegionSelectionState(region.items);
+              return (
+                <Box key={region.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => toggleOrgRegion(region.items)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && '✓'}
+                      {selectionState === 'partial' && '−'}
+                    </span>
+                    {region.region}
+                    <span style={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                      ({region.items.filter(o => filters.organizations.includes(o)).length}/{region.items.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {region.items.map((org) => (
+                      <FilterButton
+                        key={org}
+                        label={org}
+                        selected={filters.organizations.includes(org)}
+                        onClick={() => toggleOrganization(org)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {/* クリアボタン */}
+      <Box sx={sectionDivider}>
+        <Button
+          onClick={onClearAll}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={!hasConditions}
+          sx={{
+            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
+            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
+            fontSize: fontSizes.xs,
+            py: 0.75,
+            '&:hover': {
+              borderColor: colors.accent.red,
+              backgroundColor: `${colors.accent.red}1a`,
+            },
+            '&.Mui-disabled': {
+              color: rightPanelColors.textMuted,
+              borderColor: rightPanelColors.inputBorder,
+            },
+          }}
+        >
+          すべてクリア
+        </Button>
+      </Box>
+
+      {/* 検索 */}
+      <Box sx={sectionDivider}>
+        <TextField
+          placeholder="検索..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          size="small"
+          fullWidth
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              fontSize: fontSizes.sm,
+              color: rightPanelColors.text,
+              backgroundColor: rightPanelColors.inputBg,
+              '& fieldset': { borderColor: rightPanelColors.inputBorder },
+              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
+              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
+            },
+            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
+                  sx={{ color: rightPanelColors.textMuted }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* ソート/フィルター タブ */}
+      <Box>
+        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
+          <Box
+            onClick={() => setMainTab('sort')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <SortIcon sx={iconStyles.medium} />
+            ソート
+          </Box>
+          <Box
+            onClick={() => setMainTab('filter')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <FilterIcon sx={iconStyles.medium} />
+            フィルター
+            {totalFilterCount > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  padding: '2px 6px',
+                  borderRadius: borderRadius.xs,
+                  fontSize: fontSizes.xs,
+                  fontWeight: 600,
+                  backgroundColor: `${colors.accent.blue}4d`,
+                  color: colors.accent.blue,
+                }}
+              >
+                {totalFilterCount}
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* ソートコンテンツ */}
+        {mainTab === 'sort' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
+              const ascOption = `${field}_asc` as SortOption;
+              const descOption = `${field}_desc` as SortOption;
+              const isAsc = sortOption === ascOption;
+              const isDesc = sortOption === descOption;
+              const isActive = isAsc || isDesc;
+              const buttonText = !isActive
+                ? label
+                : isAsc
+                  ? `${label}：${ascLabel}↑`
+                  : `${label}：${descLabel}↓`;
+
+              return (
+                <Box
+                  component="button"
+                  key={field}
+                  onClick={() => {
+                    if (!isActive) {
+                      onSortChange(ascOption);
+                    } else if (isAsc) {
+                      onSortChange(descOption);
+                    } else {
+                      onSortChange(null);
+                    }
+                  }}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    width: '100%',
+                    px: 2,
+                    pl: isActive ? 2.5 : 2,
+                    py: 1.5,
+                    fontSize: fontSizes.md,
+                    fontWeight: isActive ? 600 : 500,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                    cursor: 'pointer',
+                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                    ...(isActive && {
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '3px',
+                        backgroundColor: colors.accent.blue,
+                      },
+                    }),
+                    '&:hover': {
+                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                      color: isActive ? colors.text.white : rightPanelColors.text,
+                    },
+                  }}
+                >
+                  {buttonText}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* フィルターコンテンツ */}
+        {mainTab === 'filter' && (
+          <Box>
+            {/* カテゴリ選択ボタン（グリッド） */}
+            <Box sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 0.75,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${rightPanelColors.border}`
+            }}>
+              {FILTER_TABS.map((tab, index) => {
+                const count = filterCounts[tab.id as keyof typeof filterCounts];
+                const isActive = activeFilterTab === index;
+                return (
+                  <Box
+                    component="button"
+                    key={tab.id}
+                    onClick={() => setActiveFilterTab(index)}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 1.25,
+                      fontSize: fontSizes.xs,
+                      fontWeight: isActive ? 600 : 500,
+                      borderRadius: borderRadius.xs,
+                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                      cursor: 'pointer',
+                      position: 'relative',
+                      overflow: 'hidden',
+                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                      ...(isActive && {
+                        '&::before': {
+                          content: '""',
+                          position: 'absolute',
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: '3px',
+                          backgroundColor: colors.accent.blue,
+                        },
+                      }),
+                      '&:hover': {
+                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                        color: isActive ? colors.text.white : rightPanelColors.text,
+                      },
+                    }}
+                  >
+                    {tab.label}
+                    {count > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          padding: '1px 5px',
+                          borderRadius: borderRadius.xs,
+                          fontSize: fontSizes.xs,
+                          fontWeight: 700,
+                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
+                          color: colors.text.white,
+                          minWidth: 14,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {count}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* フィルター詳細コンテンツ */}
+            <Box sx={{ minHeight: 100 }}>
+              {renderFilterContent()}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// 着手企業用表示条件パネル
+interface CompanyConditionsPanelProps {
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sortOption: CompanySortOption | null;
+  onSortChange: (option: CompanySortOption | null) => void;
+  filters: CompanyFilterState;
+  onFilterChange: (filters: CompanyFilterState) => void;
+  onClearAll: () => void;
+  activeTab?: 'sort' | 'filter';
+  onTabChange?: (tab: 'sort' | 'filter') => void;
+}
+
+function CompanyConditionsPanel({
+  searchQuery,
+  onSearchChange,
+  sortOption,
+  onSortChange,
+  filters,
+  onFilterChange,
+  onClearAll,
+  activeTab,
+  onTabChange,
+}: CompanyConditionsPanelProps) {
+  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
+  const [activeFilterTab, setActiveFilterTab] = useState(0);
+  const mainTab = activeTab ?? internalTab;
+  const setMainTab = (tab: 'sort' | 'filter') => {
+    setInternalTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // フィルター件数
+  const filterCounts = {
+    evaluationStatus: filters.evaluationStatuses.length,
+    workStatus: filters.workStatuses.length,
+    priority: filters.priorities.length,
+  };
+  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
+  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
+
+  // トグル関数
+  const toggleEvaluationStatus = (status: EvaluationStatus) => {
+    const newStatuses = filters.evaluationStatuses.includes(status)
+      ? filters.evaluationStatuses.filter(s => s !== status)
+      : [...filters.evaluationStatuses, status];
+    onFilterChange({ ...filters, evaluationStatuses: newStatuses });
+  };
+
+  const toggleWorkStatus = (status: 'in_progress' | 'completed') => {
+    const newStatuses = filters.workStatuses.includes(status)
+      ? filters.workStatuses.filter(s => s !== status)
+      : [...filters.workStatuses, status];
+    onFilterChange({ ...filters, workStatuses: newStatuses });
+  };
+
+  const togglePriority = (priority: 1 | 2 | 3 | 4 | 5) => {
+    const newPriorities = filters.priorities.includes(priority)
+      ? filters.priorities.filter(p => p !== priority)
+      : [...filters.priorities, priority];
+    onFilterChange({ ...filters, priorities: newPriorities });
+  };
+
+  const sectionDivider = {
+    borderBottom: `1px solid ${rightPanelColors.border}`,
+    pb: 2.5,
+    mb: 2.5,
+  };
+
+  // フィルターコンテンツをレンダリング
+  const renderFilterContent = () => {
+    const tabId = COMPANY_FILTER_TABS[activeFilterTab].id;
+
+    switch (tabId) {
+      case 'evaluationStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {EVALUATION_STATUS_OPTIONS.map((status) => {
+              const config = evaluationStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.evaluationStatuses.includes(status)}
+                  onClick={() => toggleEvaluationStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'workStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {WORK_STATUS_OPTIONS.map((status) => {
+              const config = workStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.workStatuses.includes(status)}
+                  onClick={() => toggleWorkStatus(status)}
+                  color={config.color}
+                  bgColor={`${config.color}26`}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'priority':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {PRIORITY_OPTIONS.map((priority) => {
+              const config = priorityColors[priority];
+              return (
+                <FilterButton
+                  key={priority}
+                  label={priorityLabels[priority]}
+                  selected={filters.priorities.includes(priority)}
+                  onClick={() => togglePriority(priority)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {/* クリアボタン */}
+      <Box sx={sectionDivider}>
+        <Button
+          onClick={onClearAll}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={!hasConditions}
+          sx={{
+            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
+            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
+            fontSize: fontSizes.xs,
+            py: 0.75,
+            '&:hover': {
+              borderColor: colors.accent.red,
+              backgroundColor: `${colors.accent.red}1a`,
+            },
+            '&.Mui-disabled': {
+              color: rightPanelColors.textMuted,
+              borderColor: rightPanelColors.inputBorder,
+            },
+          }}
+        >
+          すべてクリア
+        </Button>
+      </Box>
+
+      {/* 検索 */}
+      <Box sx={sectionDivider}>
+        <TextField
+          placeholder="企業名で検索..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          size="small"
+          fullWidth
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              fontSize: fontSizes.sm,
+              color: rightPanelColors.text,
+              backgroundColor: rightPanelColors.inputBg,
+              '& fieldset': { borderColor: rightPanelColors.inputBorder },
+              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
+              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
+            },
+            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
+                  sx={{ color: rightPanelColors.textMuted }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* ソート/フィルター タブ */}
+      <Box>
+        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
+          <Box
+            onClick={() => setMainTab('sort')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <SortIcon sx={iconStyles.medium} />
+            ソート
+          </Box>
+          <Box
+            onClick={() => setMainTab('filter')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <FilterIcon sx={iconStyles.medium} />
+            フィルター
+            {totalFilterCount > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  padding: '2px 6px',
+                  borderRadius: borderRadius.xs,
+                  fontSize: fontSizes.xs,
+                  fontWeight: 600,
+                  backgroundColor: `${colors.accent.blue}4d`,
+                  color: colors.accent.blue,
+                }}
+              >
+                {totalFilterCount}
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* ソートコンテンツ */}
+        {mainTab === 'sort' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {COMPANY_SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
+              const ascOption = `${field}_asc` as CompanySortOption;
+              const descOption = `${field}_desc` as CompanySortOption;
+              const isAsc = sortOption === ascOption;
+              const isDesc = sortOption === descOption;
+              const isActive = isAsc || isDesc;
+              const buttonText = !isActive
+                ? label
+                : isAsc
+                  ? `${label}：${ascLabel}↑`
+                  : `${label}：${descLabel}↓`;
+
+              return (
+                <Box
+                  component="button"
+                  key={field}
+                  onClick={() => {
+                    if (!isActive) {
+                      onSortChange(ascOption);
+                    } else if (isAsc) {
+                      onSortChange(descOption);
+                    } else {
+                      onSortChange(null);
+                    }
+                  }}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    width: '100%',
+                    px: 2,
+                    pl: isActive ? 2.5 : 2,
+                    py: 1.5,
+                    fontSize: fontSizes.md,
+                    fontWeight: isActive ? 600 : 500,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                    cursor: 'pointer',
+                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                    ...(isActive && {
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '3px',
+                        backgroundColor: colors.accent.blue,
+                      },
+                    }),
+                    '&:hover': {
+                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                      color: isActive ? colors.text.white : rightPanelColors.text,
+                    },
+                  }}
+                >
+                  {buttonText}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* フィルターコンテンツ */}
+        {mainTab === 'filter' && (
+          <Box>
+            {/* カテゴリ選択ボタン（グリッド） */}
+            <Box sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 0.75,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${rightPanelColors.border}`
+            }}>
+              {COMPANY_FILTER_TABS.map((tab, index) => {
+                const count = filterCounts[tab.id as keyof typeof filterCounts];
+                const isActive = activeFilterTab === index;
+                return (
+                  <Box
+                    component="button"
+                    key={tab.id}
+                    onClick={() => setActiveFilterTab(index)}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 1.25,
+                      fontSize: fontSizes.xs,
+                      fontWeight: isActive ? 600 : 500,
+                      borderRadius: borderRadius.xs,
+                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                      cursor: 'pointer',
+                      position: 'relative',
+                      overflow: 'hidden',
+                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                      ...(isActive && {
+                        '&::before': {
+                          content: '""',
+                          position: 'absolute',
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: '3px',
+                          backgroundColor: colors.accent.blue,
+                        },
+                      }),
+                      '&:hover': {
+                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                        color: isActive ? colors.text.white : rightPanelColors.text,
+                      },
+                    }}
+                  >
+                    {tab.label}
+                    {count > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          padding: '1px 5px',
+                          borderRadius: borderRadius.xs,
+                          fontSize: fontSizes.xs,
+                          fontWeight: 700,
+                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
+                          color: colors.text.white,
+                          minWidth: 14,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {count}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* フィルター詳細コンテンツ */}
+            <Box sx={{ minHeight: 100 }}>
+              {renderFilterContent()}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+
+// ナビゲーション追跡用
+const NAV_TRACKING_KEY = 'lastVisitedPath';
+
+export default function AnnouncementDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [activeTab, setActiveTab] = useState(0);
+  const { rightPanelOpen, toggleRightPanel, closeRightPanel, isMobile } = useSidebar();
+  const [conditionTab, setConditionTab] = useState<'sort' | 'filter'>('sort');
+
+  // 詳細ページのパスを保存（一覧に戻った時のページ復元用）
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname);
+    } catch { /* ignore */ }
+  }, [location.pathname]);
+
+  // 関連案件用の状態
+  const [relatedSearchQuery, setRelatedSearchQuery] = useState('');
+  const [relatedSortOption, setRelatedSortOption] = useState<SortOption | null>(null);
+  const [relatedFilters, setRelatedFilters] = useState<RelatedFilterState>({
+    statuses: [],
+    bidTypes: [],
+    categories: [],
+    prefectures: [],
+    organizations: [],
+  });
+  const [relatedPage, setRelatedPage] = useState(0);
+  const relatedPageSize = 25;
+
+  // 着手企業用の状態
+  const [companySearchQuery, setCompanySearchQuery] = useState('');
+  const [companySortOption, setCompanySortOption] = useState<CompanySortOption | null>(null);
+  const [companyFilters, setCompanyFilters] = useState<CompanyFilterState>({
+    evaluationStatuses: [],
+    workStatuses: [],
+    priorities: [],
+  });
+  const [companyPage, setCompanyPage] = useState(0);
+  const companyPageSize = 25;
+  const [progressingCompanies, setProgressingCompanies] = useState<ProgressingCompany[]>([]);
+  const [isProgressingLoading, setIsProgressingLoading] = useState(false);
+
+  // API からデータ取得
+  const [announcement, setAnnouncement] = useState<AnnouncementDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [documentPreviewState, setDocumentPreviewState] = useState<Record<string, PreviewState>>({});
+  const previewUrlRef = useRef<Record<string, string>>({});
+  const documentPreviewStateRef = useRef<Record<string, PreviewState>>({});
+  const previewFetchControllersRef = useRef<Record<string, AbortController>>({});
+  const abortAllPreviewFetches = useCallback(() => {
+    Object.values(previewFetchControllersRef.current).forEach((controller) => {
+      controller.abort();
+    });
+    previewFetchControllersRef.current = {};
+  }, []);
+  const revokeAllPreviewUrls = useCallback(() => {
+    Object.values(previewUrlRef.current).forEach((url) => {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    });
+    previewUrlRef.current = {};
+  }, []);
+
+  const resetPreviewState = useCallback(() => {
+    abortAllPreviewFetches();
+    revokeAllPreviewUrls();
+    setDocumentPreviewState(() => {
+      documentPreviewStateRef.current = {};
+      return {};
+    });
+  }, [abortAllPreviewFetches, revokeAllPreviewUrls]);
+
+  useEffect(() => {
+    return () => {
+      abortAllPreviewFetches();
+      revokeAllPreviewUrls();
+    };
+  }, [abortAllPreviewFetches, revokeAllPreviewUrls]);
+
+  useEffect(() => {
+    resetPreviewState();
+  }, [announcement?.announcementNo, resetPreviewState]);
+
+  useEffect(() => {
+    const fetchAnnouncement = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        // id から ann- プレフィックスを除去して公告番号を取得
+        const announcementNo = id.startsWith('ann-') ? id.substring(4) : id;
+        const response = await fetch(getApiUrl(`/api/announcements/${announcementNo}`));
+        if (!response.ok) {
+          throw new Error(`Failed to fetch announcement: ${response.status}`);
+        }
+        const data = await response.json();
+        setAnnouncement(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnnouncement();
+  }, [id]);
+
+  const loadPdfPreview = useCallback(
+    async (documentId: number, options?: { force?: boolean }) => {
+      if (!announcement?.announcementNo) return;
+      const docKey = String(documentId);
+      const forceReload = options?.force ?? false;
+      const currentState = documentPreviewStateRef.current[docKey];
+      if (!forceReload && (currentState?.loading || currentState?.url)) {
+        return;
+      }
+
+      if (forceReload && previewUrlRef.current[docKey]) {
+        URL.revokeObjectURL(previewUrlRef.current[docKey]);
+        delete previewUrlRef.current[docKey];
+      }
+
+      const existingController = previewFetchControllersRef.current[docKey];
+      if (existingController) {
+        existingController.abort();
+      }
+
+      const controller = new AbortController();
+      previewFetchControllersRef.current[docKey] = controller;
+
+      setDocumentPreviewState((prev) => {
+        const nextState = {
+          ...prev,
+          [docKey]: { loading: true },
+        };
+        documentPreviewStateRef.current = nextState;
+        return nextState;
+      });
+
+      try {
+        const response = await fetch(
+          getApiUrl(`/api/announcements/${announcement.announcementNo}/documents/${docKey}/preview`),
+          { signal: controller.signal }
+        );
+        if (!response.ok) {
+          throw new Error(`Failed to fetch preview (${response.status})`);
+        }
+        const blob = await response.blob();
+        if (controller.signal.aborted) {
+          return;
+        }
+        const objectUrl = URL.createObjectURL(blob);
+
+        if (previewUrlRef.current[docKey]) {
+          URL.revokeObjectURL(previewUrlRef.current[docKey]);
+        }
+        previewUrlRef.current[docKey] = objectUrl;
+
+        setDocumentPreviewState((prev) => {
+          const nextState = {
+            ...prev,
+            [docKey]: { loading: false, url: objectUrl },
+          };
+          documentPreviewStateRef.current = nextState;
+          return nextState;
+        });
+      } catch (err) {
+        if ((err instanceof DOMException && err.name === 'AbortError') || controller.signal.aborted) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : 'PDFプレビューの取得に失敗しました';
+        setDocumentPreviewState((prev) => {
+          const nextState = {
+            ...prev,
+            [docKey]: { loading: false, error: message },
+          };
+          documentPreviewStateRef.current = nextState;
+          return nextState;
+        });
+      } finally {
+        if (previewFetchControllersRef.current[docKey] === controller) {
+          delete previewFetchControllersRef.current[docKey];
+        }
+      }
+    },
+    [announcement?.announcementNo]
+  );
+
+  useEffect(() => {
+    if (!announcement?.documents) return;
+    const firstPdfDoc = announcement.documents.find(
+      (doc: DocumentOcr) => doc.fileFormat && doc.fileFormat.toLowerCase() === 'pdf'
+    );
+    if (firstPdfDoc) {
+      loadPdfPreview(firstPdfDoc.id);
+    }
+  }, [announcement?.documents, loadPdfPreview]);
+
+  useEffect(() => {
+    if (!announcement || !announcement.announcementNo) {
+      setProgressingCompanies([]);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const fetchProgressingCompanies = async () => {
+      setIsProgressingLoading(true);
+      try {
+        const response = await fetch(
+          getApiUrl(`/api/announcements/${announcement.announcementNo}/progressing-companies`)
+        );
+        if (!response.ok) {
+          throw new Error(`Failed to fetch progressing companies: ${response.status}`);
+        }
+        const data = await response.json();
+        if (isCancelled) return;
+        const mapped = Array.isArray(data)
+          ? data.map((row: any) => ({
+              companyId: String(row.companyId ?? ''),
+              companyName: row.companyName ?? '',
+              branchId: String(row.branchId ?? ''),
+              branchName: row.branchName ?? '',
+              priority: normalizePriority(Number(row.priority ?? 1)),
+              workStatus: normalizeWorkStatus(row.workStatus ?? ''),
+              evaluationId: String(row.evaluationId ?? ''),
+              evaluationStatus: (row.evaluationStatus ?? 'unmet') as EvaluationStatus,
+            }))
+          : [];
+        setProgressingCompanies(mapped);
+      } catch (err) {
+        console.error('Failed to fetch progressing companies:', err);
+        if (!isCancelled) {
+          setProgressingCompanies([]);
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsProgressingLoading(false);
+        }
+      }
+    };
+
+    fetchProgressingCompanies();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [announcement?.announcementNo]);
+
+  // サイドパネル制御
+  const handleOpenWithTab = useCallback((tab: 'sort' | 'filter') => {
+    setConditionTab(tab);
+    if (!rightPanelOpen) {
+      toggleRightPanel();
+    }
+  }, [rightPanelOpen, toggleRightPanel]);
+
+  // 検索変更ハンドラ
+  const handleRelatedSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setRelatedSearchQuery(e.target.value);
+    setRelatedPage(0);
+  }, []);
+
+  // 企業検索変更ハンドラ
+  const handleCompanySearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setCompanySearchQuery(e.target.value);
+    setCompanyPage(0);
+  }, []);
+
+  // 関連案件のベースデータ（メモ化）
+  // TODO: 関連案件APIを実装後に復活
+  const baseRelatedAnnouncements = useMemo((): any[] => {
+    return [];
+  }, [announcement]);
+
+  // フィルタリング・ソート済み関連案件
+  const filteredRelatedAnnouncements = useMemo(() => {
+    let filtered = baseRelatedAnnouncements;
+
+    // 検索フィルター
+    if (relatedSearchQuery) {
+      const query = relatedSearchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (a) =>
+          a.title.toLowerCase().includes(query) ||
+          a.category.toLowerCase().includes(query) ||
+          a.workLocation.toLowerCase().includes(query)
+      );
+    }
+
+    // フィルター適用
+    filtered = filtered.filter((a) => {
+      if (relatedFilters.statuses.length > 0 && !relatedFilters.statuses.includes(resolveAnnouncementStatus(a.status as string | undefined))) return false;
+      if (relatedFilters.bidTypes.length > 0 && (!a.bidType || !relatedFilters.bidTypes.includes(a.bidType))) return false;
+      if (relatedFilters.categories.length > 0 && !relatedFilters.categories.includes(a.category)) return false;
+      if (relatedFilters.prefectures.length > 0) {
+        const prefecture = a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+        if (!relatedFilters.prefectures.includes(prefecture)) return false;
+      }
+      if (relatedFilters.organizations.length > 0) {
+        const orgGroup = getOrganizationGroup(a.organization);
+        if (!relatedFilters.organizations.includes(orgGroup)) return false;
+      }
+      return true;
+    });
+
+    // ソート適用
+    if (!relatedSortOption) return filtered;
+
+    return [...filtered].sort((a, b) => {
+      switch (relatedSortOption) {
+        case 'deadline_asc':
+          return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+        case 'deadline_desc':
+          return new Date(b.deadline).getTime() - new Date(a.deadline).getTime();
+        case 'publish_asc':
+          return new Date(a.publishDate).getTime() - new Date(b.publishDate).getTime();
+        case 'publish_desc':
+          return new Date(b.publishDate).getTime() - new Date(a.publishDate).getTime();
+        case 'status_asc':
+          return getStatusOrderValue(a.status as string | undefined) - getStatusOrderValue(b.status as string | undefined);
+        case 'status_desc':
+          return getStatusOrderValue(b.status as string | undefined) - getStatusOrderValue(a.status as string | undefined);
+        case 'prefecture_asc': {
+          const prefA = a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+          const prefB = b.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+          return prefA.localeCompare(prefB, 'ja');
+        }
+        case 'prefecture_desc': {
+          const prefA = a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+          const prefB = b.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+          return prefB.localeCompare(prefA, 'ja');
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [baseRelatedAnnouncements, relatedSearchQuery, relatedFilters, relatedSortOption]);
+
+  // ページネーション済み関連案件
+  const paginatedRelatedAnnouncements = useMemo(() => {
+    const start = relatedPage * relatedPageSize;
+    return filteredRelatedAnnouncements.slice(start, start + relatedPageSize);
+  }, [filteredRelatedAnnouncements, relatedPage]);
+
+  // 関連データ（早期returnの前に計算）
+  // フィルタリング・ソート済み着手企業
+  const filteredProgressingCompanies = useMemo<ProgressingCompany[]>(() => {
+    let filtered = progressingCompanies;
+
+    // 検索フィルター
+    if (companySearchQuery) {
+      const query = companySearchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (c) =>
+          c.companyName.toLowerCase().includes(query) ||
+          c.branchName.toLowerCase().includes(query)
+      );
+    }
+
+    // フィルター適用
+    filtered = filtered.filter((c) => {
+      if (companyFilters.evaluationStatuses.length > 0 && !companyFilters.evaluationStatuses.includes(c.evaluationStatus)) return false;
+      if (companyFilters.workStatuses.length > 0 && !companyFilters.workStatuses.includes(c.workStatus)) return false;
+      if (companyFilters.priorities.length > 0 && !companyFilters.priorities.includes(c.priority)) return false;
+      return true;
+    });
+
+    // ソート適用
+    if (!companySortOption) return filtered;
+
+    return [...filtered].sort((a, b) => {
+      switch (companySortOption) {
+        case 'priority_asc':
+          return PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+        case 'priority_desc':
+          return PRIORITY_ORDER[b.priority] - PRIORITY_ORDER[a.priority];
+        case 'evaluationStatus_asc':
+          return EVALUATION_STATUS_ORDER[a.evaluationStatus] - EVALUATION_STATUS_ORDER[b.evaluationStatus];
+        case 'evaluationStatus_desc':
+          return EVALUATION_STATUS_ORDER[b.evaluationStatus] - EVALUATION_STATUS_ORDER[a.evaluationStatus];
+        case 'workStatus_asc':
+          return WORK_STATUS_ORDER[a.workStatus] - WORK_STATUS_ORDER[b.workStatus];
+        case 'workStatus_desc':
+          return WORK_STATUS_ORDER[b.workStatus] - WORK_STATUS_ORDER[a.workStatus];
+        case 'company_asc':
+          return a.companyName.localeCompare(b.companyName, 'ja');
+        case 'company_desc':
+          return b.companyName.localeCompare(a.companyName, 'ja');
+        default:
+          return 0;
+      }
+    });
+  }, [progressingCompanies, companySearchQuery, companyFilters, companySortOption]);
+
+  // ページネーション済み着手企業
+  const paginatedProgressingCompanies = useMemo<ProgressingCompany[]>(() => {
+    const start = companyPage * companyPageSize;
+    return filteredProgressingCompanies.slice(start, start + companyPageSize);
+  }, [filteredProgressingCompanies, companyPage, companyPageSize]);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography>読み込み中...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center', color: colors.status.error.main }}>
+        <Typography>{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!announcement) {
+    return (
+      <NotFoundView
+        message="指定された入札公告が見つかりません。"
+        backLabel="一覧に戻る"
+        onBack={() => navigate('/announcements')}
+      />
+    );
+  }
+
+  // タブインデックス計算用（資料タブが条件付きのため）
+  const hasDocuments = announcement.documents && announcement.documents.length > 0;
+  const tabIndex = {
+    basicInfo: 0,
+    documents: hasDocuments ? 1 : -1,
+    related: hasDocuments ? 2 : 1,
+    companies: hasDocuments ? 3 : 2,
+  };
+
+  return (
+    <Box sx={{ height: '100vh', bgcolor: colors.page.background, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <Box sx={{ ...pageStyles.contentArea, maxWidth: '100%', py: 3, display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+
+        {/* ヘッダー */}
+        <AnnouncementHeader announcement={announcement} onBack={() => navigate('/announcements')} />
+
+        {/* メインカード + サイドパネル */}
+        <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
+          <Paper
+            sx={{
+              borderRadius: borderRadius.xs,
+              overflow: 'hidden',
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            {/* タブ */}
+            <AnnouncementTabs
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              hasDocuments={!!hasDocuments}
+              relatedCount={baseRelatedAnnouncements.length}
+              companiesCount={progressingCompanies.length}
+            />
+
+            {/* タブコンテンツ */}
+            <Box sx={{ flex: 1, overflow: 'auto', backgroundColor: colors.background.hover, display: 'flex', flexDirection: 'column' }}>
+
+            {/* 基本情報タブ */}
+            {activeTab === tabIndex.basicInfo && (
+              <RequirementSection
+                announcement={announcement}
+                progressingCompanies={progressingCompanies}
+                onNavigate={navigate}
+              />
+            )}
+
+
+            {/* 着手企業タブ */}
+            {activeTab === tabIndex.companies && (
+              <CompetingCompaniesSection
+                companies={paginatedProgressingCompanies}
+                isLoading={isProgressingLoading}
+                totalCount={progressingCompanies.length}
+                page={companyPage}
+                pageSize={companyPageSize}
+                filteredCount={filteredProgressingCompanies.length}
+                onPageChange={setCompanyPage}
+                onNavigate={navigate}
+              />
+            )}
+
+            {/* 関連案件タブ */}
+            {activeTab === tabIndex.related && (
+              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                <Box sx={{ flex: 1, overflow: 'auto', p: 2.5 }}>
+                  {paginatedRelatedAnnouncements.length > 0 ? (
+                    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 1.5 }}>
+                      {paginatedRelatedAnnouncements.map((ann) => {
+                        const annStatusKey = resolveAnnouncementStatus(ann.status as string | undefined);
+                        const annStatusConfig = announcementStatusConfig[annStatusKey];
+                        const bidType = bidTypeConfig[resolveBidType(ann.bidType)];
+                        const prefecture = ann.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+                        return (
+                          <Box
+                            key={ann.id}
+                            onClick={() => navigate(`/announcements/${ann.id}`)}
+                            sx={{
+                              position: 'relative',
+                              display: 'flex',
+                              flexDirection: 'column',
+                              backgroundColor: colors.text.white,
+                              borderRadius: borderRadius.xs,
+                              border: `1px solid ${colors.border.main}`,
+                              p: 2,
+                              cursor: 'pointer',
+                              transition: 'all 0.2s ease',
+                              '&:hover': { borderColor: 'rgba(59, 130, 246, 0.4)', boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)' },
+                              '&::before': {
+                                content: '""',
+                                position: 'absolute',
+                                left: 0,
+                                top: 0,
+                                bottom: 0,
+                                width: '3px',
+                                backgroundColor: annStatusConfig.color,
+                                borderRadius: `${borderRadius.xs} 0 0 ${borderRadius.xs}`,
+                              },
+                            }}
+                          >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                              <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light }}>
+                                No. {String(ann.no).padStart(8, '0')}
+                              </Typography>
+                              <Typography sx={{ fontSize: fontSizes.xs, fontWeight: 600, color: annStatusConfig.color }}>
+                                {annStatusConfig.label}
+                              </Typography>
+                              {bidType && (
+                                <>
+                                  <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
+                                  <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                                    {bidType.label}
+                                  </Typography>
+                                </>
+                              )}
+                            </Box>
+                            <Typography sx={{ fontWeight: 600, fontSize: fontSizes.md, color: colors.text.secondary, lineHeight: 1.5, mb: 1, flex: 1, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                              {ann.title}
+                            </Typography>
+                            <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light, mb: 0.5 }}>
+                              {ann.organization}
+                            </Typography>
+                            <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light, mb: 0.75 }}>
+                              {prefecture && `${prefecture}・`}{ann.category}
+                            </Typography>
+                            <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+                              公告日 {ann.publishDate} / 締切日 {ann.deadline}
+                            </Typography>
+                          </Box>
+                        );
+                      })}
+                    </Box>
+                  ) : (
+                    <Box sx={{ p: 4, textAlign: 'center', color: colors.text.light }}>
+                      関連案件がありません
+                    </Box>
+                  )}
+                </Box>
+                <Box sx={{ backgroundColor: colors.text.white, borderTop: `1px solid ${colors.border.main}`, px: 2 }}>
+                  <CustomPagination
+                    page={relatedPage}
+                    pageSize={relatedPageSize}
+                    rowCount={filteredRelatedAnnouncements.length}
+                    onPageChange={setRelatedPage}
+                    onPageSizeChange={() => {}}
+                  />
+                </Box>
+              </Box>
+            )}
+
+            {/* 資料タブ */}
+            {activeTab === tabIndex.documents && hasDocuments && announcement.documents && (
+              <DocumentSection
+                documents={announcement.documents}
+                documentPreviewState={documentPreviewState}
+                loadPdfPreview={loadPdfPreview}
+              />
+            )}
+            </Box>
+          </Paper>
+
+          {/* 右サイドパネル（関連案件タブまたは着手企業タブの時のみ表示） */}
+          {(activeTab === tabIndex.related || activeTab === tabIndex.companies) && (
+            <RightSidePanel
+              open={rightPanelOpen}
+              onToggle={toggleRightPanel}
+              onClose={closeRightPanel}
+              onOpenWithTab={handleOpenWithTab}
+              isMobile={isMobile}
+            >
+              {activeTab === tabIndex.related ? (
+                <RelatedConditionsPanel
+                  searchQuery={relatedSearchQuery}
+                  onSearchChange={handleRelatedSearchChange}
+                  sortOption={relatedSortOption}
+                  onSortChange={setRelatedSortOption}
+                  filters={relatedFilters}
+                  onFilterChange={setRelatedFilters}
+                  onClearAll={() => {
+                    setRelatedSearchQuery('');
+                    setRelatedSortOption(null);
+                    setRelatedFilters({
+                      statuses: [],
+                      bidTypes: [],
+                      categories: [],
+                      prefectures: [],
+                      organizations: [],
+                    });
+                    setRelatedPage(0);
+                  }}
+                  activeTab={conditionTab}
+                  onTabChange={setConditionTab}
+                />
+              ) : (
+                <CompanyConditionsPanel
+                  searchQuery={companySearchQuery}
+                  onSearchChange={handleCompanySearchChange}
+                  sortOption={companySortOption}
+                  onSortChange={setCompanySortOption}
+                  filters={companyFilters}
+                  onFilterChange={setCompanyFilters}
+                  onClearAll={() => {
+                    setCompanySearchQuery('');
+                    setCompanySortOption(null);
+                    setCompanyFilters({
+                      evaluationStatuses: [],
+                      workStatuses: [],
+                      priorities: [],
+                    });
+                    setCompanyPage(0);
+                  }}
+                  activeTab={conditionTab}
+                  onTabChange={setConditionTab}
+                />
+              )}
+            </RightSidePanel>
+          )}
+        </Box>
+      </Box>
+      <FloatingBackButton onClick={() => navigate('/announcements')} />
+      <ScrollToTopButton />
+    </Box>
+  );
+}

--- a/judgesystem/source/bid_apps/postgres/frontend/app/src/pages/PartnerDetailPage.tsx
+++ b/judgesystem/source/bid_apps/postgres/frontend/app/src/pages/PartnerDetailPage.tsx
@@ -1,0 +1,1189 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Typography,
+  Paper,
+  TextField,
+  InputAdornment,
+  Tabs,
+  Tab,
+  IconButton,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  ArrowBack as ArrowBackIcon,
+  SwapVert as SortIcon,
+  FilterAlt as FilterIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import { bidTypeConfig } from '../data';
+import { colors, pageStyles, fontSizes, iconStyles, borderRadius, rightPanelColors } from '../constants/styles';
+import { workStatusConfig } from '../constants/workStatus';
+import { evaluationStatusConfig } from '../constants/status';
+import { priorityLabels, priorityColors } from '../constants/priority';
+import { categories } from '../constants/categories';
+import { bidTypes } from '../constants/bidType';
+import { prefecturesByRegion } from '../constants/prefectures';
+import { organizationGroupsByRegion } from '../constants/organizations';
+import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
+import { RightSidePanel } from '../components/layout';
+import { PartnerBasicInfo, PartnerQualifications, PartnerHistory } from '../components/partner';
+import { useSidebar } from '../contexts/SidebarContext';
+import type { PastProject } from '../types/partner';
+import type { BidType } from '../types/announcement';
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../types';
+import { getApiUrl } from '../config/api';
+
+// ソートオプション
+type SortOption =
+  | 'deadline_asc' | 'deadline_desc'
+  | 'evaluationStatus_asc' | 'evaluationStatus_desc'
+  | 'workStatus_asc' | 'workStatus_desc'
+  | 'priority_asc' | 'priority_desc'
+  | 'prefecture_asc' | 'prefecture_desc'
+  | 'evaluatedAt_asc' | 'evaluatedAt_desc';
+
+// ソートフィールド定義
+const SORT_FIELDS = [
+  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
+  { field: 'evaluationStatus', label: '参加可否', ascLabel: '可能→不可', descLabel: '不可→可能' },
+  { field: 'workStatus', label: '着手状況', ascLabel: '未着手→完了', descLabel: '完了→未着手' },
+  { field: 'priority', label: '優先度', ascLabel: '高→低', descLabel: '低→高' },
+  { field: 'prefecture', label: '都道府県', ascLabel: 'あ→わ', descLabel: 'わ→あ' },
+  { field: 'evaluatedAt', label: '判定日', ascLabel: '古い→新しい', descLabel: '新しい→古い' },
+] as const;
+
+// フィルタータブ定義
+const FILTER_TABS = [
+  { id: 'evaluationStatus', label: '参加可否' },
+  { id: 'priority', label: '優先度' },
+  { id: 'workStatus', label: '着手状況' },
+  { id: 'bidType', label: '入札方式' },
+  { id: 'category', label: '種別' },
+  { id: 'prefecture', label: '都道府県' },
+  { id: 'organization', label: '発注機関' },
+] as const;
+
+// フィルター状態の型
+interface ProjectFilterState {
+  workStatuses: WorkStatus[];
+  evaluationStatuses: EvaluationStatus[];
+  priorities: CompanyPriority[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+  organizations: string[];
+}
+
+// WorkStatus, EvaluationStatus, Priority の配列
+const WORK_STATUS_OPTIONS: WorkStatus[] = ['not_started', 'in_progress', 'completed'];
+const EVALUATION_STATUS_OPTIONS: EvaluationStatus[] = ['all_met', 'other_only_unmet', 'unmet'];
+const PRIORITY_OPTIONS: CompanyPriority[] = [1, 2, 3, 4, 5];
+
+// WorkStatusの順序（ソート用）
+const WORK_STATUS_ORDER: Record<WorkStatus, number> = {
+  not_started: 0,
+  in_progress: 1,
+  completed: 2,
+};
+
+// EvaluationStatusの順序（ソート用：all_met→other_only_unmet→unmet）
+const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
+  all_met: 0,
+  other_only_unmet: 1,
+  unmet: 2,
+};
+
+// フィルターボタン
+function FilterButton({
+  label,
+  selected,
+  onClick,
+  color,
+  bgColor,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  color?: string;
+  bgColor?: string;
+}) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        position: 'relative',
+        padding: '6px 12px',
+        paddingLeft: selected ? '14px' : '12px',
+        borderRadius: borderRadius.xs,
+        fontSize: fontSizes.xs,
+        fontWeight: selected ? 600 : 500,
+        cursor: 'pointer',
+        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
+        transition: 'all 0.2s ease',
+        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
+        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
+        overflow: 'hidden',
+        ...(selected && {
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: '3px',
+            backgroundColor: color || colors.accent.blue,
+          },
+        }),
+        '&:hover': {
+          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+          color: selected ? (color || colors.text.white) : rightPanelColors.text,
+          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
+        },
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+// 案件用表示条件パネル
+interface ProjectConditionsPanelProps {
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sortOption: SortOption | null;
+  onSortChange: (option: SortOption | null) => void;
+  filters: ProjectFilterState;
+  onFilterChange: (filters: ProjectFilterState) => void;
+  onClearAll: () => void;
+  activeTab?: 'sort' | 'filter';
+  onTabChange?: (tab: 'sort' | 'filter') => void;
+  projects: PastProject[];
+}
+
+function ProjectConditionsPanel({
+  searchQuery,
+  onSearchChange,
+  sortOption,
+  onSortChange,
+  filters,
+  onFilterChange,
+  onClearAll,
+  activeTab,
+  onTabChange,
+  projects,
+}: ProjectConditionsPanelProps) {
+  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
+  const [activeFilterTab, setActiveFilterTab] = useState(0);
+  const mainTab = activeTab ?? internalTab;
+  const setMainTab = (tab: 'sort' | 'filter') => {
+    setInternalTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // ステータス件数（元データから計算）
+  const statusCounts = useMemo(() => ({
+    all_met: projects.filter(p => p.evaluationStatus === 'all_met').length,
+    other_only_unmet: projects.filter(p => p.evaluationStatus === 'other_only_unmet').length,
+    unmet: projects.filter(p => p.evaluationStatus === 'unmet').length,
+  }), [projects]);
+
+  // フィルター件数
+  const filterCounts = {
+    workStatus: filters.workStatuses.length,
+    evaluationStatus: filters.evaluationStatuses.length,
+    priority: filters.priorities.length,
+    bidType: filters.bidTypes.length,
+    category: filters.categories.length,
+    prefecture: filters.prefectures.length,
+    organization: filters.organizations.length,
+  };
+  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
+  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
+
+  // トグル関数
+  const toggleWorkStatus = (status: WorkStatus) => {
+    const newStatuses = filters.workStatuses.includes(status)
+      ? filters.workStatuses.filter(s => s !== status)
+      : [...filters.workStatuses, status];
+    onFilterChange({ ...filters, workStatuses: newStatuses });
+  };
+
+  const toggleEvaluationStatus = (status: EvaluationStatus) => {
+    const newStatuses = filters.evaluationStatuses.includes(status)
+      ? filters.evaluationStatuses.filter(s => s !== status)
+      : [...filters.evaluationStatuses, status];
+    onFilterChange({ ...filters, evaluationStatuses: newStatuses });
+  };
+
+  const togglePriority = (priority: CompanyPriority) => {
+    const newPriorities = filters.priorities.includes(priority)
+      ? filters.priorities.filter(p => p !== priority)
+      : [...filters.priorities, priority];
+    onFilterChange({ ...filters, priorities: newPriorities });
+  };
+
+  const toggleBidType = (bidType: string) => {
+    const newBidTypes = filters.bidTypes.includes(bidType)
+      ? filters.bidTypes.filter(b => b !== bidType)
+      : [...filters.bidTypes, bidType];
+    onFilterChange({ ...filters, bidTypes: newBidTypes });
+  };
+
+  const toggleCategory = (category: string) => {
+    const newCategories = filters.categories.includes(category)
+      ? filters.categories.filter(c => c !== category)
+      : [...filters.categories, category];
+    onFilterChange({ ...filters, categories: newCategories });
+  };
+
+  const togglePrefecture = (pref: string) => {
+    const newPrefs = filters.prefectures.includes(pref)
+      ? filters.prefectures.filter(p => p !== pref)
+      : [...filters.prefectures, pref];
+    onFilterChange({ ...filters, prefectures: newPrefs });
+  };
+
+  const togglePrefRegion = (regionItems: readonly string[]) => {
+    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
+      });
+    } else {
+      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
+      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
+    }
+  };
+
+  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const toggleOrganization = (org: string) => {
+    const newOrgs = filters.organizations.includes(org)
+      ? filters.organizations.filter(o => o !== org)
+      : [...filters.organizations, org];
+    onFilterChange({ ...filters, organizations: newOrgs });
+  };
+
+  const toggleOrgRegion = (regionItems: string[]) => {
+    const allSelected = regionItems.every(item => filters.organizations.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        organizations: filters.organizations.filter(o => !regionItems.includes(o)),
+      });
+    } else {
+      const newOrgs = new Set([...filters.organizations, ...regionItems]);
+      onFilterChange({ ...filters, organizations: Array.from(newOrgs) });
+    }
+  };
+
+  const getOrgRegionSelectionState = (regionItems: string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.organizations.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const sectionDivider = {
+    borderBottom: `1px solid ${rightPanelColors.border}`,
+    pb: 2.5,
+    mb: 2.5,
+  };
+
+  // フィルターコンテンツをレンダリング
+  const renderFilterContent = () => {
+    const tabId = FILTER_TABS[activeFilterTab].id;
+
+    switch (tabId) {
+      case 'workStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {WORK_STATUS_OPTIONS.map((status) => {
+              const config = workStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.workStatuses.includes(status)}
+                  onClick={() => toggleWorkStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'evaluationStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {EVALUATION_STATUS_OPTIONS.map((status) => {
+              const config = evaluationStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={`${config.label} (${statusCounts[status]})`}
+                  selected={filters.evaluationStatuses.includes(status)}
+                  onClick={() => toggleEvaluationStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'priority':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {PRIORITY_OPTIONS.map((priority) => {
+              const pColor = priorityColors[priority];
+              return (
+                <FilterButton
+                  key={priority}
+                  label={priorityLabels[priority]}
+                  selected={filters.priorities.includes(priority)}
+                  onClick={() => togglePriority(priority)}
+                  color={pColor.color}
+                  bgColor={pColor.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'bidType':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {bidTypes.map((bidType: BidType) => {
+              const config = bidTypeConfig[bidType];
+              return (
+                <FilterButton
+                  key={bidType}
+                  label={config.label}
+                  selected={filters.bidTypes.includes(bidType)}
+                  onClick={() => toggleBidType(bidType)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'category':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {categories.map((cat) => (
+              <FilterButton
+                key={cat}
+                label={cat}
+                selected={filters.categories.includes(cat)}
+                onClick={() => toggleCategory(cat)}
+              />
+            ))}
+          </Box>
+        );
+
+      case 'prefecture':
+        return (
+          <Box>
+            {prefecturesByRegion.map((region) => {
+              const selectionState = getPrefRegionSelectionState(region.prefectures);
+              return (
+                <Box key={region.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => togglePrefRegion(region.prefectures)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && '✓'}
+                      {selectionState === 'partial' && '−'}
+                    </span>
+                    {region.region}
+                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
+                      ({region.prefectures.filter(item => filters.prefectures.includes(item)).length}/{region.prefectures.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {region.prefectures.map((pref) => (
+                      <FilterButton
+                        key={pref}
+                        label={pref}
+                        selected={filters.prefectures.includes(pref)}
+                        onClick={() => togglePrefecture(pref)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      case 'organization':
+        return (
+          <Box>
+            {organizationGroupsByRegion.map((group) => {
+              const selectionState = getOrgRegionSelectionState(group.items);
+              return (
+                <Box key={group.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => toggleOrgRegion(group.items)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && '✓'}
+                      {selectionState === 'partial' && '−'}
+                    </span>
+                    {group.region}
+                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
+                      ({group.items.filter(item => filters.organizations.includes(item)).length}/{group.items.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {group.items.map((org) => (
+                      <FilterButton
+                        key={org}
+                        label={org}
+                        selected={filters.organizations.includes(org)}
+                        onClick={() => toggleOrganization(org)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {/* クリアボタン */}
+      <Box sx={sectionDivider}>
+        <Button
+          onClick={onClearAll}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={!hasConditions}
+          sx={{
+            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
+            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
+            fontSize: fontSizes.xs,
+            py: 0.75,
+            '&:hover': {
+              borderColor: colors.accent.red,
+              backgroundColor: `${colors.accent.red}1a`,
+            },
+            '&.Mui-disabled': {
+              color: rightPanelColors.textMuted,
+              borderColor: rightPanelColors.inputBorder,
+            },
+          }}
+        >
+          すべてクリア
+        </Button>
+      </Box>
+
+      {/* 検索 */}
+      <Box sx={sectionDivider}>
+        <TextField
+          placeholder="検索..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          size="small"
+          fullWidth
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              fontSize: fontSizes.sm,
+              color: rightPanelColors.text,
+              backgroundColor: rightPanelColors.inputBg,
+              '& fieldset': { borderColor: rightPanelColors.inputBorder },
+              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
+              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
+            },
+            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
+                  sx={{ color: rightPanelColors.textMuted }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* ソート/フィルター タブ */}
+      <Box>
+        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
+          <Box
+            onClick={() => setMainTab('sort')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <SortIcon sx={iconStyles.medium} />
+            ソート
+          </Box>
+          <Box
+            onClick={() => setMainTab('filter')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <FilterIcon sx={iconStyles.medium} />
+            フィルター
+            {totalFilterCount > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  padding: '2px 6px',
+                  borderRadius: borderRadius.xs,
+                  fontSize: fontSizes.xs,
+                  fontWeight: 600,
+                  backgroundColor: `${colors.accent.blue}4d`,
+                  color: colors.accent.blue,
+                }}
+              >
+                {totalFilterCount}
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* ソートコンテンツ */}
+        {mainTab === 'sort' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
+              const ascOption = `${field}_asc` as SortOption;
+              const descOption = `${field}_desc` as SortOption;
+              const isAsc = sortOption === ascOption;
+              const isDesc = sortOption === descOption;
+              const isActive = isAsc || isDesc;
+              const buttonText = !isActive
+                ? label
+                : isAsc
+                  ? `${label}：${ascLabel}↑`
+                  : `${label}：${descLabel}↓`;
+
+              return (
+                <Box
+                  component="button"
+                  key={field}
+                  onClick={() => {
+                    if (!isActive) {
+                      onSortChange(ascOption);
+                    } else if (isAsc) {
+                      onSortChange(descOption);
+                    } else {
+                      onSortChange(null);
+                    }
+                  }}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    width: '100%',
+                    px: 2,
+                    pl: isActive ? 2.5 : 2,
+                    py: 1.5,
+                    fontSize: fontSizes.md,
+                    fontWeight: isActive ? 600 : 500,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                    cursor: 'pointer',
+                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                    ...(isActive && {
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '3px',
+                        backgroundColor: colors.accent.blue,
+                      },
+                    }),
+                    '&:hover': {
+                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                      color: isActive ? colors.text.white : rightPanelColors.text,
+                    },
+                  }}
+                >
+                  {buttonText}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* フィルターコンテンツ */}
+        {mainTab === 'filter' && (
+          <Box>
+            {/* カテゴリ選択ボタン（グリッド） */}
+            <Box sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 0.75,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${rightPanelColors.border}`
+            }}>
+              {FILTER_TABS.map((tab, index) => {
+                const count = filterCounts[tab.id as keyof typeof filterCounts];
+                const isActive = activeFilterTab === index;
+                const handleDoubleClick = () => {
+                  switch (tab.id) {
+                    case 'evaluationStatus':
+                      onFilterChange({ ...filters, evaluationStatuses: [] });
+                      break;
+                    case 'priority':
+                      onFilterChange({ ...filters, priorities: [] });
+                      break;
+                    case 'workStatus':
+                      onFilterChange({ ...filters, workStatuses: [] });
+                      break;
+                    case 'bidType':
+                      onFilterChange({ ...filters, bidTypes: [] });
+                      break;
+                    case 'category':
+                      onFilterChange({ ...filters, categories: [] });
+                      break;
+                    case 'prefecture':
+                      onFilterChange({ ...filters, prefectures: [] });
+                      break;
+                    case 'organization':
+                      onFilterChange({ ...filters, organizations: [] });
+                      break;
+                  }
+                };
+                return (
+                  <Box
+                    component="button"
+                    key={tab.id}
+                    onClick={() => setActiveFilterTab(index)}
+                    onDoubleClick={handleDoubleClick}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 1.25,
+                      fontSize: fontSizes.sm,
+                      fontWeight: isActive ? 600 : 500,
+                      borderRadius: borderRadius.xs,
+                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                      cursor: 'pointer',
+                      position: 'relative',
+                      overflow: 'hidden',
+                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                      transition: 'all 0.2s ease',
+                      ...(isActive && {
+                        '&::before': {
+                          content: '""',
+                          position: 'absolute',
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: '3px',
+                          backgroundColor: colors.accent.blue,
+                        },
+                      }),
+                      '&:hover': {
+                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                        color: isActive ? colors.text.white : rightPanelColors.text,
+                        borderColor: isActive ? colors.accent.blue : `${colors.text.light}99`,
+                      },
+                    }}
+                  >
+                    {tab.label}
+                    {count > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          padding: '1px 5px',
+                          borderRadius: borderRadius.xs,
+                          fontSize: fontSizes.xs,
+                          fontWeight: 700,
+                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
+                          color: colors.text.white,
+                          minWidth: 14,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {count}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* フィルター詳細コンテンツ */}
+            <Box sx={{ minHeight: 100 }}>
+              {renderFilterContent()}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// ナビゲーション追跡用
+const NAV_TRACKING_KEY = 'lastVisitedPath';
+
+export default function PartnerDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [activeTab, setActiveTab] = useState(0);
+  const { rightPanelOpen, toggleRightPanel, closeRightPanel, isMobile } = useSidebar();
+  const [conditionTab, setConditionTab] = useState<'sort' | 'filter'>('sort');
+
+  // APIからデータ取得
+  const [partner, setPartner] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 詳細ページのパスを保存（一覧に戻った時のページ復元用）
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname);
+    } catch { /* ignore */ }
+  }, [location.pathname]);
+
+  // パートナー情報をAPIから取得
+  useEffect(() => {
+    const fetchPartner = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(getApiUrl(`/api/partners/${id}`));
+        if (!response.ok) {
+          throw new Error(`Failed to fetch partner: ${response.status}`);
+        }
+        const data = await response.json();
+        setPartner(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPartner();
+  }, [id]);
+
+  // 対応案件のページネーション・検索状態
+  const [projectSearchQuery, setProjectSearchQuery] = useState('');
+  const [projectPage, setProjectPage] = useState(0);
+  const projectPageSize = 25;
+
+  // ソート・フィルター状態
+  const [sortOption, setSortOption] = useState<SortOption | null>(null);
+  const [filters, setFilters] = useState<ProjectFilterState>({
+    workStatuses: [],
+    evaluationStatuses: [],
+    priorities: [],
+    bidTypes: [],
+    categories: [],
+    prefectures: [],
+    organizations: [],
+  });
+
+  // サイドパネル制御
+  const handleOpenWithTab = useCallback((tab: 'sort' | 'filter') => {
+    setConditionTab(tab);
+    if (!rightPanelOpen) {
+      toggleRightPanel();
+    }
+  }, [rightPanelOpen, toggleRightPanel]);
+
+  // 対応案件のフィルタリング
+  const filteredProjects = useMemo((): PastProject[] => {
+    if (!partner) return [];
+    const pastProjects = partner.pastProjects || [];
+    if (!Array.isArray(pastProjects)) return [];
+
+    // 検索フィルター
+    let filtered = pastProjects;
+    if (projectSearchQuery) {
+      const query = projectSearchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (p: PastProject) =>
+          p.announcementTitle.toLowerCase().includes(query) ||
+          p.category.toLowerCase().includes(query) ||
+          p.prefecture.toLowerCase().includes(query) ||
+          p.branchName.toLowerCase().includes(query)
+      );
+    }
+
+    // フィルター適用
+    filtered = filtered.filter((p: PastProject) => {
+      if (filters.workStatuses.length > 0 && !filters.workStatuses.includes(p.workStatus)) return false;
+      if (filters.evaluationStatuses.length > 0 && !filters.evaluationStatuses.includes(p.evaluationStatus)) return false;
+      if (filters.priorities.length > 0) {
+        if (p.priority == null || !filters.priorities.includes(p.priority as CompanyPriority)) return false;
+      }
+      if (filters.bidTypes.length > 0 && (!p.bidType || !filters.bidTypes.includes(p.bidType))) return false;
+      if (filters.categories.length > 0 && !filters.categories.includes(p.category)) return false;
+      if (filters.prefectures.length > 0 && !filters.prefectures.includes(p.prefecture)) return false;
+      if (filters.organizations.length > 0 && !filters.organizations.includes(p.organization)) return false;
+      return true;
+    });
+
+    // ソート適用
+    if (!sortOption) return filtered;
+
+    return [...filtered].sort((a, b) => {
+      switch (sortOption) {
+        case 'deadline_asc':
+          return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+        case 'deadline_desc':
+          return new Date(b.deadline).getTime() - new Date(a.deadline).getTime();
+        case 'evaluationStatus_asc':
+          return EVALUATION_STATUS_ORDER[a.evaluationStatus as EvaluationStatus] - EVALUATION_STATUS_ORDER[b.evaluationStatus as EvaluationStatus];
+        case 'evaluationStatus_desc':
+          return EVALUATION_STATUS_ORDER[b.evaluationStatus as EvaluationStatus] - EVALUATION_STATUS_ORDER[a.evaluationStatus as EvaluationStatus];
+        case 'workStatus_asc':
+          return WORK_STATUS_ORDER[a.workStatus as WorkStatus] - WORK_STATUS_ORDER[b.workStatus as WorkStatus];
+        case 'workStatus_desc':
+          return WORK_STATUS_ORDER[b.workStatus as WorkStatus] - WORK_STATUS_ORDER[a.workStatus as WorkStatus];
+        case 'priority_asc': {
+          const aPriority = a.priority;
+          const bPriority = b.priority;
+          if (aPriority == null && bPriority == null) return 0;
+          if (aPriority == null) return 1;
+          if (bPriority == null) return -1;
+          return aPriority - bPriority;
+        }
+        case 'priority_desc': {
+          const aPriority = a.priority;
+          const bPriority = b.priority;
+          if (aPriority == null && bPriority == null) return 0;
+          if (aPriority == null) return 1;
+          if (bPriority == null) return -1;
+          return bPriority - aPriority;
+        }
+        case 'prefecture_asc':
+          return a.prefecture.localeCompare(b.prefecture, 'ja');
+        case 'prefecture_desc':
+          return b.prefecture.localeCompare(a.prefecture, 'ja');
+        case 'evaluatedAt_asc':
+          return new Date(a.evaluatedAt).getTime() - new Date(b.evaluatedAt).getTime();
+        case 'evaluatedAt_desc':
+          return new Date(b.evaluatedAt).getTime() - new Date(a.evaluatedAt).getTime();
+        default:
+          return 0;
+      }
+    });
+  }, [partner, projectSearchQuery, filters, sortOption]);
+
+  // ページネーションされた対応案件
+  const paginatedProjects = useMemo(() => {
+    const start = projectPage * projectPageSize;
+    return filteredProjects.slice(start, start + projectPageSize);
+  }, [filteredProjects, projectPage]);
+
+  // 検索変更ハンドラ
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setProjectSearchQuery(e.target.value);
+    setProjectPage(0);
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography>読み込み中...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center', color: colors.status.error.main }}>
+        <Typography>{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!partner) {
+    return (
+      <NotFoundView
+        message="指定された会社が見つかりません。"
+        backLabel="一覧に戻る"
+        onBack={() => navigate('/partners')}
+      />
+    );
+  }
+
+  // データ構造の保証（デフォルト値設定）
+  const safePartner = {
+    ...partner,
+    branches: partner.branches || [],
+    categories: partner.categories || [],
+    pastProjects: partner.pastProjects || [],
+    qualifications: partner.qualifications || { unified: [], orderers: [] },
+  };
+
+  return (
+    <Box sx={{ height: '100vh', bgcolor: colors.page.background, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <Box sx={{ ...pageStyles.contentArea, maxWidth: '100%', py: 3, display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        {/* ヘッダー */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
+          <Box sx={{ pl: 2, borderLeft: '4px solid', borderColor: colors.accent.blue }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
+              <Button
+                size="small"
+                startIcon={<ArrowBackIcon sx={iconStyles.small} />}
+                onClick={() => navigate('/partners')}
+                sx={{
+                  color: colors.text.muted,
+                  fontWeight: 500,
+                  fontSize: fontSizes.sm,
+                  textTransform: 'none',
+                  px: 1,
+                  py: 0.25,
+                  minWidth: 'auto',
+                  '&:hover': { backgroundColor: colors.border.light },
+                }}
+              >
+                一覧に戻る
+              </Button>
+            </Box>
+            <Typography sx={pageStyles.detailPageTitle}>
+              {safePartner.name}
+            </Typography>
+          </Box>
+          <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 3, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+              No. {String(safePartner.no).padStart(8, '0')}
+            </Typography>
+            <Typography sx={{ fontSize: fontSizes.xl, fontWeight: 700, color: colors.accent.blue }}>
+              <Typography component="span" sx={{ fontSize: fontSizes.sm, fontWeight: 500, color: colors.text.muted }}>
+                対応案件実績{" "}
+              </Typography>
+              {safePartner.pastProjects.length}件
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* メインカード + サイドパネル */}
+        <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
+          <Paper sx={{ borderRadius: borderRadius.xs, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)', flex: 1, display: 'flex', flexDirection: 'column' }}>
+            {/* タブ */}
+            <Box sx={{ borderBottom: `1px solid ${colors.border.main}`, backgroundColor: colors.text.white }}>
+              <Tabs
+                value={activeTab}
+                onChange={(_, v) => setActiveTab(v)}
+                sx={{
+                  px: 2,
+                  '& .MuiTabs-indicator': { backgroundColor: colors.primary.main, height: 2 },
+                  '& .MuiTab-root': { textTransform: 'none', fontSize: fontSizes.md, fontWeight: 500, color: colors.text.muted, minWidth: 'auto', px: 2, py: 1.5, '&.Mui-selected': { color: colors.primary.main, fontWeight: 600 } },
+                }}
+              >
+                <Tab label="基本情報" />
+                <Tab label={`対応案件 (${safePartner.pastProjects.length})`} />
+              </Tabs>
+            </Box>
+
+            {/* タブコンテンツ */}
+            <Box sx={{ flex: 1, overflow: 'auto', backgroundColor: colors.background.hover, display: 'flex', flexDirection: 'column' }}>
+            {/* 基本情報タブ */}
+            {activeTab === 0 && (
+              <Box sx={{ p: 2.5 }}>
+                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
+                  {/* 左カラム */}
+                  <PartnerBasicInfo partner={safePartner} />
+
+                  {/* 右カラム */}
+                  <PartnerQualifications partner={safePartner} />
+                </Box>
+              </Box>
+            )}
+
+            {/* 対応案件タブ */}
+            {activeTab === 1 && (
+              <PartnerHistory
+                projects={paginatedProjects}
+                page={projectPage}
+                pageSize={projectPageSize}
+                filteredCount={filteredProjects.length}
+                onPageChange={setProjectPage}
+                onNavigate={navigate}
+              />
+            )}
+            </Box>
+          </Paper>
+
+          {/* 右サイドパネル（対応案件タブの時のみ表示） */}
+          {activeTab === 1 && (
+            <RightSidePanel
+              open={rightPanelOpen}
+              onToggle={toggleRightPanel}
+              onClose={closeRightPanel}
+              onOpenWithTab={handleOpenWithTab}
+              isMobile={isMobile}
+            >
+              <ProjectConditionsPanel
+                searchQuery={projectSearchQuery}
+                onSearchChange={handleSearchChange}
+                sortOption={sortOption}
+                onSortChange={setSortOption}
+                filters={filters}
+                onFilterChange={setFilters}
+                onClearAll={() => {
+                  setProjectSearchQuery('');
+                  setSortOption(null);
+                  setFilters({
+                    workStatuses: [],
+                    evaluationStatuses: [],
+                    priorities: [],
+                    bidTypes: [],
+                    categories: [],
+                    prefectures: [],
+                    organizations: [],
+                  });
+                  setProjectPage(0);
+                }}
+                activeTab={conditionTab}
+                onTabChange={setConditionTab}
+                projects={partner?.pastProjects || []}
+              />
+            </RightSidePanel>
+          )}
+        </Box>
+      </Box>
+      <FloatingBackButton onClick={() => navigate('/partners')} />
+      <ScrollToTopButton />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Miyabi自律パイプラインによるjudgesystemのPhase 1リファクタリングコードをmy-appに登録。

- 2つのExploreAgentで並列分析 → 4つのCodeGenAgentで並列実装
- judgesystem本体は変更なし（修正後コードのみmy-appに配置）

### Backend (6ファイル)
- **DBマイグレーションシステム**: `schema_migrations`テーブル + 7インデックス
- **GCS N+1修正**: `readMultipleMarkdownFromGCS` バッチフェッチ
- **ヘルスチェック**: `GET /health`（DB接続確認付き）
- **構造化ログ**: JSON形式リクエストログ
- **グレースフルシャットダウン**: SIGTERM/SIGINT対応

### Frontend (14ファイル)
- **AnnouncementDetailPage分割**: 4サブコンポーネント抽出 (2435→1896 LOC)
- **PartnerDetailPage分割**: 3サブコンポーネント抽出 (1507→1189 LOC)
- **ErrorBoundary追加**: 詳細ページクラッシュ保護

### ファイル配置
```
my-app/judgesystem/source/bid_apps/postgres/
├── backend/app/           # Express API (修正済み)
└── frontend/app/src/      # React (修正済み)
```

## Test plan

- [ ] 修正後コードの構造確認
- [ ] TypeScript型チェック
- [ ] judgesystem本体に変更がないことの確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Miyabi Autonomous Pipeline