### PR TITLE
refactor: judgesystem コード品質改善・機能追加 (#15-#27)

### DIFF
--- a/judgesystem/backend/app/index.ts
+++ b/judgesystem/backend/app/index.ts
@@ -1,16 +1,16 @@
 import express from "express";
 import cors from "cors";
 import compression from "compression";
-import {
-  EvaluationController,
-  AnnouncementController,
-  PartnerController,
-  OrdererController,
-  ContactController,
-  CompanyController,
-} from "./src/controllers";
 import { pool } from "./src/config/database";
 import { runMigrations } from "./src/config/migrations";
+import {
+  evaluationRoutes,
+  announcementRoutes,
+  partnerRoutes,
+  ordererRoutes,
+  contactRoutes,
+  companyRoutes,
+} from "./src/routes";
 
 const app = express();
 
@@ -22,11 +22,7 @@ app.use(cors({
 }));
 
 app.options("*", cors());
-
-// gzip圧縮を有効化
 app.use(compression());
-
-// Middleware to parse JSON body (must be before routes)
 app.use(express.json());
 
 // Request logging middleware
@@ -45,13 +41,12 @@ app.use((req, res, next) => {
   next();
 });
 
-// Root path
-app.get("/", (req, res) => {
+// Root & health
+app.get("/", (_req, res) => {
   res.send("Backend API is running");
 });
 
-// Health check endpoint
-app.get("/health", async (req, res) => {
+app.get("/health", async (_req, res) => {
   try {
     const client = await pool.connect();
     await client.query("SELECT 1");
@@ -67,49 +62,15 @@ app.get("/health", async (req, res) => {
   }
 });
 
-// Initialize controllers
-const evaluationController = new EvaluationController();
-const announcementController = new AnnouncementController();
-const partnerController = new PartnerController();
-const ordererController = new OrdererController();
-const contactController = new ContactController();
-const companyController = new CompanyController();
+// Domain routes
+app.use("/api/evaluations", evaluationRoutes);
+app.use("/api/announcements", announcementRoutes);
+app.use("/api/partners", partnerRoutes);
+app.use("/api/orderers", ordererRoutes);
+app.use("/api/contacts", contactRoutes);
+app.use("/api/companies", companyRoutes);
 
-// Evaluation routes
-app.get("/api/evaluations/stats", evaluationController.getStats);
-app.get("/api/evaluations/status-counts", evaluationController.getStatusCounts);
-app.get("/api/evaluations", evaluationController.getList);
-app.get("/api/evaluations/:id", evaluationController.getById);
-app.patch("/api/evaluations/:evaluationNo", evaluationController.updateWorkStatus);
-app.get("/api/evaluations/:evaluationNo/assignees", evaluationController.getAssignees);
-app.put("/api/evaluations/:evaluationNo/assignees", evaluationController.updateAssignee);
-
-// Announcement routes
-app.get("/api/announcements", announcementController.getList);
-app.get("/api/announcements/:announcementNo", announcementController.getByNo);
-app.get("/api/announcements/:announcementNo/progressing-companies", announcementController.getProgressingCompanies);
-app.get("/api/announcements/:announcementNo/similar-cases", announcementController.getSimilarCases);
-app.get("/api/announcements/:announcementNo/documents/:documentId/preview", announcementController.getDocumentPreview);
-
-// Partner routes
-app.get("/api/partners", partnerController.getList);
-app.get("/api/partners/:id", partnerController.getById);
-
-// Orderer routes
-app.get("/api/orderers", ordererController.getList);
-app.get("/api/orderers/:id", ordererController.getById);
-
-// Contact routes
-app.get("/api/contacts", contactController.getList);
-app.get("/api/contacts/:id", contactController.getById);
-app.post("/api/contacts", contactController.create);
-app.patch("/api/contacts/:id", contactController.update);
-app.delete("/api/contacts/:id", contactController.delete);
-
-// Company routes
-app.get("/api/companies", companyController.getList);
-
-// Cloud Run は PORT 環境変数を使う
+// Start server
 const port = process.env.PORT || 8080;
 
 (async () => {

--- a/judgesystem/backend/app/src/config/database.ts
+++ b/judgesystem/backend/app/src/config/database.ts
@@ -1,0 +1,47 @@
+import { Pool, PoolConfig } from "pg";
+
+const shouldEnableSsl = (): boolean => {
+  const flag = (process.env.PGSSLMODE ?? process.env.PGSSL ?? "").toLowerCase();
+  return flag === "require" || flag === "true";
+};
+
+const buildPoolConfig = (): PoolConfig => {
+  const config: PoolConfig = process.env.DATABASE_URL
+    ? { connectionString: process.env.DATABASE_URL }
+    : {
+        host: process.env.PGHOST ?? "127.0.0.1",
+        port: Number(process.env.PGPORT ?? "5432"),
+        database: process.env.PGDATABASE ?? "postgres",
+        user: process.env.PGUSER ?? "postgres",
+        password: process.env.PGPASSWORD,
+      };
+
+  if (shouldEnableSsl()) {
+    config.ssl = {
+      rejectUnauthorized:
+        (process.env.PGSSL_REJECT_UNAUTHORIZED ?? "false").toLowerCase() === "true",
+    };
+  }
+
+  return config;
+};
+
+export const pool = new Pool(buildPoolConfig());
+
+export const TABLES = {
+  orderers: "bid_orderers",
+  contacts: "workflow_contacts",
+  partners: "partners_master",
+  partnerCategories: "partners_categories",
+  partnerPastProjects: "partners_past_projects",
+  partnerBranches: "partners_branches",
+  partnerQualificationsUnified: "partners_qualifications_unified",
+  partnerQualificationsOrderers: "partners_qualifications_orderers",
+  partnerQualificationsOrdererItems: "partners_qualifications_orderer_items",
+  evaluationStatuses: "backend_evaluation_statuses",
+  evaluationAssignees: "evaluation_assignees",
+  companyMaster: "company_master",
+  officeMaster: "office_master",
+} as const;
+
+export const schemaPrefix = process.env.PG_SCHEMA ? `${process.env.PG_SCHEMA}.` : "";

--- a/judgesystem/backend/app/src/config/env.ts
+++ b/judgesystem/backend/app/src/config/env.ts
@@ -1,0 +1,51 @@
+/**
+ * Environment variable validation and type-safe access.
+ * Validates on import — server fails fast if config is invalid.
+ */
+
+interface EnvConfig {
+  PORT: number;
+  CORS_ORIGIN: string;
+  DATABASE_URL: string | undefined;
+  PGHOST: string;
+  PGPORT: number;
+  PGDATABASE: string;
+  PGUSER: string;
+  PGPASSWORD: string | undefined;
+  PGSSLMODE: string;
+  PG_SCHEMA: string;
+  GCS_BUCKET: string | undefined;
+}
+
+function parseEnv(): EnvConfig {
+  const port = Number(process.env.PORT || "8080");
+  if (isNaN(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT: "${process.env.PORT}". Must be a number between 1 and 65535.`);
+  }
+
+  const corsOrigin = process.env.CORS_ORIGIN || "http://localhost:5173";
+
+  // Database: either DATABASE_URL or individual PG* vars
+  const databaseUrl = process.env.DATABASE_URL;
+  const pgHost = process.env.PGHOST ?? "127.0.0.1";
+  const pgPort = Number(process.env.PGPORT ?? "5432");
+  if (isNaN(pgPort)) {
+    throw new Error(`Invalid PGPORT: "${process.env.PGPORT}". Must be a number.`);
+  }
+
+  return {
+    PORT: port,
+    CORS_ORIGIN: corsOrigin,
+    DATABASE_URL: databaseUrl,
+    PGHOST: pgHost,
+    PGPORT: pgPort,
+    PGDATABASE: process.env.PGDATABASE ?? "postgres",
+    PGUSER: process.env.PGUSER ?? "postgres",
+    PGPASSWORD: process.env.PGPASSWORD,
+    PGSSLMODE: (process.env.PGSSLMODE ?? process.env.PGSSL ?? "").toLowerCase(),
+    PG_SCHEMA: process.env.PG_SCHEMA ?? "",
+    GCS_BUCKET: process.env.GCS_BUCKET,
+  };
+}
+
+export const env = parseEnv();

--- a/judgesystem/backend/app/src/repositories/announcementRepository.ts
+++ b/judgesystem/backend/app/src/repositories/announcementRepository.ts
@@ -311,6 +311,74 @@ export class AnnouncementRepository {
   }
 
   /**
+   * Get document file for preview/download.
+   * Fetches metadata from DB, then downloads actual file from GCS.
+   */
+  async getDocumentFile(
+    announcementNo: number,
+    documentId: string
+  ): Promise<{ data: Buffer; fileFormat: string; title: string } | null> {
+    const meta = await this.findDocumentMeta(announcementNo, documentId);
+    if (!meta) return null;
+
+    const gcsPath = meta.save_path;
+    if (!gcsPath || !gcsPath.startsWith("gs://")) {
+      return null;
+    }
+
+    const { downloadFileFromGCS } = await import("../utils/gcs");
+    const data = await downloadFileFromGCS(gcsPath);
+
+    return {
+      data,
+      fileFormat: meta.fileFormat || "pdf",
+      title: meta.title || `document-${documentId}`,
+    };
+  }
+
+  /**
+   * Find related announcements by same category/organization/location.
+   */
+  async findRelated(announcementNo: number): Promise<any[]> {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `
+        WITH target AS (
+          SELECT category, "topAgencyName", "workPlace"
+          FROM ${schemaPrefix}bid_announcements
+          WHERE announcement_no = $1
+        )
+        SELECT
+          CONCAT('ann-', a.announcement_no) AS id,
+          a.announcement_no AS no,
+          a.announcement_no AS "announcementNo",
+          COALESCE(a."workName", '') AS title,
+          COALESCE(a."topAgencyName", '') AS organization,
+          COALESCE(a.category, '') AS category,
+          COALESCE(a."bidType", 'unknown') AS "bidType",
+          COALESCE(a."workPlace", '') AS "workLocation",
+          COALESCE(a."publishDate", '') AS "publishDate",
+          COALESCE(a."bidEndDate", '') AS deadline
+        FROM ${schemaPrefix}bid_announcements a, target t
+        WHERE a.announcement_no != $1
+          AND (
+            a.category = t.category
+            OR a."topAgencyName" = t."topAgencyName"
+            OR a."workPlace" = t."workPlace"
+          )
+        ORDER BY a."bidEndDate" DESC NULLS LAST
+        LIMIT 50
+        `,
+        [announcementNo]
+      );
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
    * Build WHERE clause from filters (pure data column filters only)
    * bid_announcements テーブルのカラム名に対応
    */

--- a/judgesystem/backend/app/src/repositories/evaluationRepository.ts
+++ b/judgesystem/backend/app/src/repositories/evaluationRepository.ts
@@ -486,6 +486,50 @@ export class EvaluationRepository {
     return '';
   }
 
+  /**
+   * Find assignees for a given evaluation
+   */
+  async findAssignees(evaluationNo: string): Promise<any[]> {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `SELECT step_id AS "stepId", contact_id::text AS "staffId", assigned_at AS "assignedAt"
+         FROM ${schemaPrefix}${TABLES.evaluationAssignees}
+         WHERE evaluation_no::text = $1
+         ORDER BY step_id`,
+        [evaluationNo]
+      );
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Upsert an assignee for an evaluation step
+   */
+  async updateAssignee(
+    evaluationNo: string,
+    body: { stepId: string; staffId: string }
+  ): Promise<any | null> {
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `INSERT INTO ${schemaPrefix}${TABLES.evaluationAssignees}
+           (evaluation_no, step_id, contact_id, assigned_at)
+         VALUES ($1, $2, $3, NOW())
+         ON CONFLICT (evaluation_no, step_id) DO UPDATE
+         SET contact_id = EXCLUDED.contact_id, assigned_at = NOW()
+         RETURNING evaluation_no AS "evaluationNo", step_id AS "stepId",
+                   contact_id::text AS "staffId", assigned_at AS "assignedAt"`,
+        [evaluationNo, body.stepId, body.staffId]
+      );
+      return result.rowCount === 0 ? null : result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
   private getQualifiedTables(): QualifiedTables {
     return {
       companyBidJudgement: `${schemaPrefix}company_bid_judgement`,

--- a/judgesystem/backend/app/src/routes/announcementRoutes.ts
+++ b/judgesystem/backend/app/src/routes/announcementRoutes.ts
@@ -1,0 +1,104 @@
+import { Router, Request, Response } from "express";
+import { AnnouncementService } from "../services/announcementService";
+import { parseFilterParams } from "../utils/validation";
+
+const router = Router();
+const service = new AnnouncementService();
+
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const filters = parseFilterParams(req.query as Record<string, any>);
+    const result = await service.getList(filters);
+    res.json(result);
+  } catch (err) {
+    console.error("GET /api/announcements error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:announcementNo", async (req: Request, res: Response) => {
+  try {
+    const no = Number(req.params.announcementNo);
+    if (isNaN(no)) {
+      res.status(400).json({ error: "Invalid announcement number" });
+      return;
+    }
+    const announcement = await service.getByNo(no);
+    if (!announcement) {
+      res.status(404).json({ error: "Announcement not found" });
+      return;
+    }
+    res.json(announcement);
+  } catch (err) {
+    console.error("GET /api/announcements/:announcementNo error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:announcementNo/progressing-companies", async (req: Request, res: Response) => {
+  try {
+    const no = Number(req.params.announcementNo);
+    if (isNaN(no)) {
+      res.status(400).json({ error: "Invalid announcement number" });
+      return;
+    }
+    const companies = await service.getProgressingCompanies(no);
+    res.json(companies);
+  } catch (err) {
+    console.error("GET /api/announcements/:announcementNo/progressing-companies error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:announcementNo/similar-cases", async (req: Request, res: Response) => {
+  try {
+    const no = Number(req.params.announcementNo);
+    if (isNaN(no)) {
+      res.status(400).json({ error: "Invalid announcement number" });
+      return;
+    }
+    const cases = await service.getSimilarCases(no);
+    res.json(cases);
+  } catch (err) {
+    console.error("GET /api/announcements/:announcementNo/similar-cases error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:announcementNo/related", async (req: Request, res: Response) => {
+  try {
+    const no = Number(req.params.announcementNo);
+    if (isNaN(no)) {
+      res.status(400).json({ error: "Invalid announcement number" });
+      return;
+    }
+    const related = await service.getRelated(no);
+    res.json(related);
+  } catch (err) {
+    console.error("GET /api/announcements/:announcementNo/related error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:announcementNo/documents/:documentId/preview", async (req: Request, res: Response) => {
+  try {
+    const no = Number(req.params.announcementNo);
+    if (isNaN(no)) {
+      res.status(400).json({ error: "Invalid announcement number" });
+      return;
+    }
+    const result = await service.getDocumentPreview(no, req.params.documentId);
+    if (!result) {
+      res.status(404).json({ error: "Document not found" });
+      return;
+    }
+    res.setHeader("Content-Type", `application/${result.fileFormat || "pdf"}`);
+    res.setHeader("Content-Disposition", `inline; filename="${result.title}"`);
+    res.send(result.data);
+  } catch (err) {
+    console.error("GET /api/announcements/:announcementNo/documents/:documentId/preview error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/routes/companyRoutes.ts
+++ b/judgesystem/backend/app/src/routes/companyRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from "express";
+import { pool, TABLES, schemaPrefix } from "../config/database";
+
+const router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+        company_no::text AS id,
+        COALESCE(company_name, '') AS name,
+        COALESCE(company_address, '') AS address
+      FROM ${schemaPrefix}${TABLES.companyMaster}
+      ORDER BY company_name`
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error("GET /api/companies error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/routes/contactRoutes.ts
+++ b/judgesystem/backend/app/src/routes/contactRoutes.ts
@@ -1,0 +1,119 @@
+import { Router, Request, Response } from "express";
+import { pool, TABLES, schemaPrefix } from "../config/database";
+
+const router = Router();
+const table = () => `${schemaPrefix}${TABLES.contacts}`;
+
+router.get("/", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+        contact_id::text AS id,
+        COALESCE(contact_name, '') AS name,
+        COALESCE(contact_email, '') AS email,
+        COALESCE(contact_telephone, '') AS phone
+      FROM ${table()}
+      ORDER BY contact_id DESC`
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error("GET /api/contacts error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.get("/:id", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+        contact_id::text AS id,
+        COALESCE(contact_name, '') AS name,
+        COALESCE(contact_email, '') AS email,
+        COALESCE(contact_telephone, '') AS phone
+      FROM ${table()}
+      WHERE contact_id::text = $1`,
+      [req.params.id]
+    );
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: "Contact not found" });
+      return;
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error("GET /api/contacts/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.post("/", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const { name, email, phone } = req.body;
+    const result = await client.query(
+      `INSERT INTO ${table()} (contact_name, contact_email, contact_telephone)
+       VALUES ($1, $2, $3)
+       RETURNING contact_id::text AS id, contact_name AS name, contact_email AS email, contact_telephone AS phone`,
+      [name, email, phone]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    console.error("POST /api/contacts error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.patch("/:id", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const { name, email, phone } = req.body;
+    const result = await client.query(
+      `UPDATE ${table()}
+       SET contact_name = COALESCE($2, contact_name),
+           contact_email = COALESCE($3, contact_email),
+           contact_telephone = COALESCE($4, contact_telephone)
+       WHERE contact_id::text = $1
+       RETURNING contact_id::text AS id, contact_name AS name, contact_email AS email, contact_telephone AS phone`,
+      [req.params.id, name, email, phone]
+    );
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: "Contact not found" });
+      return;
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error("PATCH /api/contacts/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.delete("/:id", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `DELETE FROM ${table()} WHERE contact_id::text = $1 RETURNING contact_id::text AS id`,
+      [req.params.id]
+    );
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: "Contact not found" });
+      return;
+    }
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error("DELETE /api/contacts/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/routes/evaluationRoutes.ts
+++ b/judgesystem/backend/app/src/routes/evaluationRoutes.ts
@@ -1,0 +1,108 @@
+import { Router, Request, Response } from "express";
+import { EvaluationService } from "../services/evaluationService";
+import { parseFilterParams } from "../utils/validation";
+
+const router = Router();
+const service = new EvaluationService();
+
+router.get("/stats", async (req: Request, res: Response) => {
+  try {
+    const stats = await service.getStats();
+    res.json(stats);
+  } catch (err) {
+    console.error("GET /api/evaluations/stats error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/status-counts", async (req: Request, res: Response) => {
+  try {
+    const filters = parseFilterParams(req.query as Record<string, any>);
+    const counts = await service.getStatusCounts(filters);
+    res.json(counts);
+  } catch (err) {
+    console.error("GET /api/evaluations/status-counts error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const filters = parseFilterParams(req.query as Record<string, any>);
+    const result = await service.getList(filters);
+    res.json(result);
+  } catch (err) {
+    console.error("GET /api/evaluations error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:id", async (req: Request, res: Response) => {
+  try {
+    const evaluation = await service.getById(req.params.id);
+    if (!evaluation) {
+      res.status(404).json({ error: "Evaluation not found" });
+      return;
+    }
+    res.json(evaluation);
+  } catch (err) {
+    console.error("GET /api/evaluations/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.patch("/:evaluationNo", async (req: Request, res: Response) => {
+  try {
+    const { workStatus, currentStep } = req.body;
+    if (!workStatus) {
+      res.status(400).json({ error: "workStatus is required" });
+      return;
+    }
+    const result = await service.updateWorkStatus(
+      req.params.evaluationNo,
+      workStatus,
+      currentStep
+    );
+    if (!result) {
+      res.status(404).json({ error: "Evaluation not found" });
+      return;
+    }
+    res.json(result);
+  } catch (err: any) {
+    if (err.message?.startsWith("Invalid")) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
+    console.error("PATCH /api/evaluations/:evaluationNo error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.get("/:evaluationNo/assignees", async (req: Request, res: Response) => {
+  try {
+    const assignees = await service.getAssignees(req.params.evaluationNo);
+    res.json(assignees);
+  } catch (err) {
+    console.error("GET /api/evaluations/:evaluationNo/assignees error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.put("/:evaluationNo/assignees", async (req: Request, res: Response) => {
+  try {
+    const result = await service.updateAssignee(
+      req.params.evaluationNo,
+      req.body
+    );
+    if (!result) {
+      res.status(404).json({ error: "Evaluation not found" });
+      return;
+    }
+    res.json(result);
+  } catch (err) {
+    console.error("PUT /api/evaluations/:evaluationNo/assignees error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/routes/index.ts
+++ b/judgesystem/backend/app/src/routes/index.ts
@@ -1,0 +1,6 @@
+export { default as evaluationRoutes } from "./evaluationRoutes";
+export { default as announcementRoutes } from "./announcementRoutes";
+export { default as partnerRoutes } from "./partnerRoutes";
+export { default as ordererRoutes } from "./ordererRoutes";
+export { default as contactRoutes } from "./contactRoutes";
+export { default as companyRoutes } from "./companyRoutes";

--- a/judgesystem/backend/app/src/routes/ordererRoutes.ts
+++ b/judgesystem/backend/app/src/routes/ordererRoutes.ts
@@ -1,0 +1,66 @@
+import { Router, Request, Response } from "express";
+import { pool, TABLES, schemaPrefix } from "../config/database";
+
+const router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const page = Number(req.query.page ?? 0);
+    const pageSize = Number(req.query.pageSize ?? 25);
+    const offset = page * pageSize;
+
+    const countResult = await client.query(
+      `SELECT COUNT(*) as count FROM ${schemaPrefix}${TABLES.orderers}`
+    );
+    const total = parseInt(countResult.rows[0].count);
+
+    const result = await client.query(
+      `SELECT
+        orderer_id::text AS id,
+        COALESCE(orderer_name, '') AS name,
+        COALESCE(orderer_address, '') AS address
+      FROM ${schemaPrefix}${TABLES.orderers}
+      ORDER BY orderer_id DESC
+      LIMIT $1 OFFSET $2`,
+      [pageSize, offset]
+    );
+
+    res.json({ data: result.rows, total, page, pageSize });
+  } catch (err) {
+    console.error("GET /api/orderers error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.get("/:id", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+        orderer_id::text AS id,
+        COALESCE(orderer_name, '') AS name,
+        COALESCE(orderer_address, '') AS address,
+        COALESCE(orderer_telephone, '') AS phone
+      FROM ${schemaPrefix}${TABLES.orderers}
+      WHERE orderer_id::text = $1`,
+      [req.params.id]
+    );
+
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: "Orderer not found" });
+      return;
+    }
+
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error("GET /api/orderers/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/routes/partnerRoutes.ts
+++ b/judgesystem/backend/app/src/routes/partnerRoutes.ts
@@ -1,0 +1,69 @@
+import { Router, Request, Response } from "express";
+import { pool, TABLES, schemaPrefix } from "../config/database";
+
+const router = Router();
+
+router.get("/", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const page = Number(req.query.page ?? 0);
+    const pageSize = Number(req.query.pageSize ?? 25);
+    const offset = page * pageSize;
+
+    const countResult = await client.query(
+      `SELECT COUNT(*) as count FROM ${schemaPrefix}${TABLES.partners}`
+    );
+    const total = parseInt(countResult.rows[0].count);
+
+    const result = await client.query(
+      `SELECT
+        partner_no::text AS id,
+        partner_no AS no,
+        COALESCE(partner_name, '') AS name,
+        COALESCE(partner_address, '') AS address
+      FROM ${schemaPrefix}${TABLES.partners}
+      ORDER BY partner_no DESC
+      LIMIT $1 OFFSET $2`,
+      [pageSize, offset]
+    );
+
+    res.json({ data: result.rows, total, page, pageSize });
+  } catch (err) {
+    console.error("GET /api/partners error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+router.get("/:id", async (req: Request, res: Response) => {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+        p.partner_no::text AS id,
+        p.partner_no AS no,
+        COALESCE(p.partner_name, '') AS name,
+        COALESCE(p.partner_address, '') AS address,
+        COALESCE(p.partner_telephone, '') AS phone,
+        COALESCE(p.partner_email, '') AS email
+      FROM ${schemaPrefix}${TABLES.partners} p
+      WHERE p.partner_no::text = $1`,
+      [req.params.id]
+    );
+
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: "Partner not found" });
+      return;
+    }
+
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error("GET /api/partners/:id error:", err);
+    res.status(500).json({ error: "Internal server error" });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/judgesystem/backend/app/src/services/__tests__/announcementService.test.ts
+++ b/judgesystem/backend/app/src/services/__tests__/announcementService.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  determineAnnouncementStatus,
+  normalizeBidType,
+} from "../announcementService";
+
+describe("determineAnnouncementStatus", () => {
+  let realDate: typeof Date;
+
+  beforeEach(() => {
+    realDate = globalThis.Date;
+    // Fix "now" to 2025-06-15 00:00:00
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'closed' for null", () => {
+    expect(determineAnnouncementStatus(null)).toBe("closed");
+  });
+
+  it("returns 'closed' for undefined", () => {
+    expect(determineAnnouncementStatus(undefined)).toBe("closed");
+  });
+
+  it("returns 'closed' for empty string", () => {
+    expect(determineAnnouncementStatus("")).toBe("closed");
+  });
+
+  it("returns 'closed' for invalid date format", () => {
+    expect(determineAnnouncementStatus("not-a-date")).toBe("closed");
+  });
+
+  it("returns 'upcoming' when end date is 14+ days in the future", () => {
+    // 2025-06-30 is 15 days after 2025-06-15
+    expect(determineAnnouncementStatus("2025-06-30")).toBe("upcoming");
+  });
+
+  it("returns 'ongoing' when end date is within 14 days", () => {
+    // 2025-06-20 is 5 days after 2025-06-15
+    expect(determineAnnouncementStatus("2025-06-20")).toBe("ongoing");
+  });
+
+  it("returns 'ongoing' when end date is today", () => {
+    expect(determineAnnouncementStatus("2025-06-15")).toBe("ongoing");
+  });
+
+  it("returns 'awaiting_result' when end date is in the past", () => {
+    expect(determineAnnouncementStatus("2025-06-01")).toBe("awaiting_result");
+  });
+
+  it("returns 'upcoming' for exactly 14 days boundary", () => {
+    // 2025-06-29 is exactly 14 days after 2025-06-15
+    expect(determineAnnouncementStatus("2025-06-29")).toBe("upcoming");
+  });
+
+  it("returns 'ongoing' for 13 days in future (just under boundary)", () => {
+    // 2025-06-28 is 13 days
+    expect(determineAnnouncementStatus("2025-06-28")).toBe("ongoing");
+  });
+});
+
+describe("normalizeBidType", () => {
+  it("returns value when valid", () => {
+    expect(normalizeBidType("general-competitive-bidding")).toBe("general-competitive-bidding");
+    expect(normalizeBidType("design-competition")).toBe("design-competition");
+  });
+
+  it("returns 'unknown' for null", () => {
+    expect(normalizeBidType(null)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for undefined", () => {
+    expect(normalizeBidType(undefined)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for empty string", () => {
+    expect(normalizeBidType("")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for whitespace-only string", () => {
+    expect(normalizeBidType("   ")).toBe("unknown");
+  });
+});

--- a/judgesystem/backend/app/src/services/__tests__/documentService.test.ts
+++ b/judgesystem/backend/app/src/services/__tests__/documentService.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DocumentService } from "../documentService";
+
+// Mock GCS utilities
+vi.mock("../../utils/gcs", () => ({
+  readMultipleMarkdownFromGCS: vi.fn(),
+  downloadFileFromGCS: vi.fn(),
+}));
+
+import { readMultipleMarkdownFromGCS, downloadFileFromGCS } from "../../utils/gcs";
+
+const mockedReadMultiple = vi.mocked(readMultipleMarkdownFromGCS);
+const mockedDownload = vi.mocked(downloadFileFromGCS);
+
+describe("DocumentService", () => {
+  let service: DocumentService;
+
+  beforeEach(() => {
+    service = new DocumentService();
+    vi.clearAllMocks();
+  });
+
+  describe("attachDocumentContents", () => {
+    it("returns empty array for empty input", async () => {
+      expect(await service.attachDocumentContents([])).toEqual([]);
+    });
+
+    it("returns empty array for null input", async () => {
+      expect(await service.attachDocumentContents(null as any)).toEqual([]);
+    });
+
+    it("enriches documents with GCS content", async () => {
+      const docs = [
+        { id: 1, title: "doc1", markdown_path: "gs://bucket/path1.md" },
+        { id: 2, title: "doc2", markdown_path: "gs://bucket/path2.md" },
+      ];
+
+      mockedReadMultiple.mockResolvedValue(["# Content 1", "# Content 2"]);
+
+      const result = await service.attachDocumentContents(docs);
+
+      expect(mockedReadMultiple).toHaveBeenCalledWith(
+        ["gs://bucket/path1.md", "gs://bucket/path2.md"],
+        "文字起こしデータがありません"
+      );
+
+      expect(result[0].content).toBe("# Content 1");
+      expect(result[0].markdown_path).toBeUndefined();
+      expect(result[1].content).toBe("# Content 2");
+      expect(result[1].markdown_path).toBeUndefined();
+    });
+
+    it("uses fallback for documents without markdown_path", async () => {
+      const docs = [
+        { id: 1, title: "doc1" },
+        { id: 2, title: "doc2", markdown_path: "gs://bucket/path.md" },
+      ];
+
+      mockedReadMultiple.mockResolvedValue(["# Content"]);
+
+      const result = await service.attachDocumentContents(docs);
+
+      expect(result[0].content).toBe("文字起こしデータがありません");
+      expect(result[1].content).toBe("# Content");
+    });
+
+    it("skips non-gs:// paths", async () => {
+      const docs = [
+        { id: 1, title: "doc1", markdown_path: "http://example.com/file.md" },
+        { id: 2, title: "doc2", markdown_path: "gs://bucket/path.md" },
+      ];
+
+      mockedReadMultiple.mockResolvedValue(["# Content"]);
+
+      const result = await service.attachDocumentContents(docs);
+
+      expect(mockedReadMultiple).toHaveBeenCalledWith(
+        ["gs://bucket/path.md"],
+        "文字起こしデータがありません"
+      );
+      expect(result[0].content).toBe("文字起こしデータがありません");
+      expect(result[1].content).toBe("# Content");
+    });
+  });
+
+  describe("downloadDocument", () => {
+    it("downloads file from valid GCS path", async () => {
+      const buffer = Buffer.from("pdf-content");
+      mockedDownload.mockResolvedValue(buffer);
+
+      const result = await service.downloadDocument("gs://bucket/file.pdf");
+
+      expect(mockedDownload).toHaveBeenCalledWith("gs://bucket/file.pdf");
+      expect(result).toBe(buffer);
+    });
+
+    it("throws for invalid path", async () => {
+      await expect(service.downloadDocument("")).rejects.toThrow("Invalid GCS path");
+      await expect(service.downloadDocument("http://example.com")).rejects.toThrow("Invalid GCS path");
+    });
+  });
+});

--- a/judgesystem/backend/app/src/services/__tests__/evaluationService.test.ts
+++ b/judgesystem/backend/app/src/services/__tests__/evaluationService.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import {
+  determineEvaluationStatus,
+  defaultWorkStatus,
+  defaultCurrentStep,
+  defaultPriority,
+  validateWorkStatus,
+  validateCurrentStep,
+} from "../evaluationService";
+
+describe("determineEvaluationStatus", () => {
+  it("returns 'all_met' when final_status is true", () => {
+    expect(
+      determineEvaluationStatus({
+        final_status: true,
+        requirement_ineligibility: false,
+        requirement_grade_item: false,
+        requirement_location: false,
+        requirement_experience: false,
+        requirement_technician: false,
+        requirement_other: false,
+      })
+    ).toBe("all_met");
+  });
+
+  it("returns 'other_only_unmet' when all requirements met except other", () => {
+    expect(
+      determineEvaluationStatus({
+        final_status: false,
+        requirement_ineligibility: true,
+        requirement_grade_item: true,
+        requirement_location: true,
+        requirement_experience: true,
+        requirement_technician: true,
+        requirement_other: false,
+      })
+    ).toBe("other_only_unmet");
+  });
+
+  it("returns 'unmet' when any core requirement is not met", () => {
+    expect(
+      determineEvaluationStatus({
+        final_status: false,
+        requirement_ineligibility: true,
+        requirement_grade_item: false,
+        requirement_location: true,
+        requirement_experience: true,
+        requirement_technician: true,
+        requirement_other: false,
+      })
+    ).toBe("unmet");
+  });
+
+  it("returns 'unmet' when all requirements met including other", () => {
+    expect(
+      determineEvaluationStatus({
+        final_status: false,
+        requirement_ineligibility: true,
+        requirement_grade_item: true,
+        requirement_location: true,
+        requirement_experience: true,
+        requirement_technician: true,
+        requirement_other: true,
+      })
+    ).toBe("unmet");
+  });
+
+  it("returns 'unmet' when all fields are false/undefined", () => {
+    expect(determineEvaluationStatus({})).toBe("unmet");
+  });
+
+  it("final_status takes priority over other requirements", () => {
+    expect(
+      determineEvaluationStatus({
+        final_status: true,
+        requirement_ineligibility: false,
+        requirement_grade_item: false,
+        requirement_location: false,
+        requirement_experience: false,
+        requirement_technician: false,
+        requirement_other: true,
+      })
+    ).toBe("all_met");
+  });
+});
+
+describe("defaultWorkStatus", () => {
+  it("returns value when valid", () => {
+    expect(defaultWorkStatus("in_progress")).toBe("in_progress");
+    expect(defaultWorkStatus("completed")).toBe("completed");
+  });
+
+  it("returns 'not_started' for null", () => {
+    expect(defaultWorkStatus(null)).toBe("not_started");
+  });
+
+  it("returns 'not_started' for undefined", () => {
+    expect(defaultWorkStatus(undefined)).toBe("not_started");
+  });
+
+  it("returns 'not_started' for empty string", () => {
+    expect(defaultWorkStatus("")).toBe("not_started");
+  });
+});
+
+describe("defaultCurrentStep", () => {
+  it("returns value when valid", () => {
+    expect(defaultCurrentStep("document_review")).toBe("document_review");
+  });
+
+  it("returns 'judgment' for null", () => {
+    expect(defaultCurrentStep(null)).toBe("judgment");
+  });
+
+  it("returns 'judgment' for undefined", () => {
+    expect(defaultCurrentStep(undefined)).toBe("judgment");
+  });
+
+  it("returns 'judgment' for empty string", () => {
+    expect(defaultCurrentStep("")).toBe("judgment");
+  });
+});
+
+describe("defaultPriority", () => {
+  it("returns value when provided", () => {
+    expect(defaultPriority(3)).toBe(3);
+    expect(defaultPriority(0)).toBe(0);
+  });
+
+  it("returns 1 for null", () => {
+    expect(defaultPriority(null)).toBe(1);
+  });
+
+  it("returns 1 for undefined", () => {
+    expect(defaultPriority(undefined)).toBe(1);
+  });
+});
+
+describe("validateWorkStatus", () => {
+  it("accepts valid statuses", () => {
+    expect(() => validateWorkStatus("not_started")).not.toThrow();
+    expect(() => validateWorkStatus("in_progress")).not.toThrow();
+    expect(() => validateWorkStatus("completed")).not.toThrow();
+    expect(() => validateWorkStatus("on_hold")).not.toThrow();
+    expect(() => validateWorkStatus("cancelled")).not.toThrow();
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => validateWorkStatus("invalid")).toThrow(/Invalid workStatus/);
+    expect(() => validateWorkStatus("")).toThrow(/Invalid workStatus/);
+  });
+});
+
+describe("validateCurrentStep", () => {
+  it("accepts valid steps", () => {
+    expect(() => validateCurrentStep("judgment")).not.toThrow();
+    expect(() => validateCurrentStep("document_review")).not.toThrow();
+    expect(() => validateCurrentStep("field_survey")).not.toThrow();
+    expect(() => validateCurrentStep("final_review")).not.toThrow();
+  });
+
+  it("rejects invalid step", () => {
+    expect(() => validateCurrentStep("invalid")).toThrow(/Invalid currentStep/);
+    expect(() => validateCurrentStep("")).toThrow(/Invalid currentStep/);
+  });
+});

--- a/judgesystem/backend/app/src/services/announcementService.ts
+++ b/judgesystem/backend/app/src/services/announcementService.ts
@@ -1,10 +1,7 @@
 import { AnnouncementRepository } from "../repositories/announcementRepository";
 import { DocumentService } from "./documentService";
-import { FilterParams } from "../types";
-
-// -- Status determination (single implementation, no duplication with SQL) --
-
-type AnnouncementStatus = "upcoming" | "ongoing" | "awaiting_result" | "closed";
+import type { FilterParams, AnnouncementStatus } from "../../../../shared/types";
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from "../../../../shared/constants";
 
 /**
  * Determine announcement status from the bid end date.
@@ -99,8 +96,8 @@ export class AnnouncementService {
   async getList(
     filters: FilterParams
   ): Promise<{ data: any[]; total: number; page: number; pageSize: number }> {
-    const page = filters.page ?? 0;
-    const pageSize = filters.pageSize ?? 25;
+    const page = filters.page ?? DEFAULT_PAGE;
+    const pageSize = filters.pageSize ?? DEFAULT_PAGE_SIZE;
 
     const result = await this.repository.findWithFilters({
       ...filters,
@@ -160,6 +157,13 @@ export class AnnouncementService {
     documentId: string
   ): Promise<{ data: Buffer; fileFormat: string; title: string } | null> {
     return this.repository.getDocumentFile(announcementNo, documentId);
+  }
+
+  /**
+   * Get related announcements sharing category/organization/location.
+   */
+  async getRelated(announcementNo: number): Promise<any[]> {
+    return this.repository.findRelated(announcementNo);
   }
 
   /**

--- a/judgesystem/backend/app/src/services/evaluationService.ts
+++ b/judgesystem/backend/app/src/services/evaluationService.ts
@@ -1,23 +1,9 @@
 import { EvaluationRepository } from "../repositories/evaluationRepository";
 import { DocumentService } from "./documentService";
-import { FilterParams } from "../types";
-
-// -- Status determination types --
-
-type EvaluationStatus = "all_met" | "other_only_unmet" | "unmet";
-
-type WorkStatus =
-  | "not_started"
-  | "in_progress"
-  | "completed"
-  | "on_hold"
-  | "cancelled";
-
-type CurrentStep =
-  | "judgment"
-  | "document_review"
-  | "field_survey"
-  | "final_review";
+import type { FilterParams } from "../../../../shared/types";
+import type { EvaluationStatus, WorkStatus, CurrentStep } from "../../../../shared/types";
+import { VALID_WORK_STATUSES, VALID_CURRENT_STEPS } from "../../../../shared/types";
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from "../../../../shared/constants";
 
 // -- Raw row shape from repository (the boolean flags come from SQL) --
 
@@ -85,22 +71,7 @@ export function defaultPriority(raw: number | null | undefined): number {
 
 // -- Validation --
 
-const VALID_WORK_STATUSES: ReadonlySet<string> = new Set([
-  "not_started",
-  "in_progress",
-  "completed",
-  "on_hold",
-  "cancelled",
-]);
-
-const VALID_CURRENT_STEPS: ReadonlySet<string> = new Set([
-  "judgment",
-  "document_review",
-  "field_survey",
-  "final_review",
-]);
-
-function validateWorkStatus(value: string): void {
+export function validateWorkStatus(value: string): void {
   if (!VALID_WORK_STATUSES.has(value)) {
     throw new Error(
       `Invalid workStatus: "${value}". Must be one of: ${[...VALID_WORK_STATUSES].join(", ")}`
@@ -108,7 +79,7 @@ function validateWorkStatus(value: string): void {
   }
 }
 
-function validateCurrentStep(value: string): void {
+export function validateCurrentStep(value: string): void {
   if (!VALID_CURRENT_STEPS.has(value)) {
     throw new Error(
       `Invalid currentStep: "${value}". Must be one of: ${[...VALID_CURRENT_STEPS].join(", ")}`
@@ -142,8 +113,8 @@ export class EvaluationService {
   async getList(
     filters: FilterParams
   ): Promise<{ data: any[]; total: number; page: number; pageSize: number }> {
-    const page = filters.page ?? 0;
-    const pageSize = filters.pageSize ?? 25;
+    const page = filters.page ?? DEFAULT_PAGE;
+    const pageSize = filters.pageSize ?? DEFAULT_PAGE_SIZE;
 
     const result = await this.repository.findWithFilters({
       ...filters,
@@ -217,31 +188,29 @@ export class EvaluationService {
   async getStatusCounts(
     filters: FilterParams
   ): Promise<{ all_met: number; other_only_unmet: number; unmet: number }> {
-    return this.repository.getStatusCounts(filters);
+    const rows = await this.repository.getStatusCountsRaw(filters);
+    const counts = { all_met: 0, other_only_unmet: 0, unmet: 0 };
+    for (const row of rows) {
+      const status = determineEvaluationStatus(row);
+      counts[status]++;
+    }
+    return counts;
   }
 
   /**
    * Get assignees for an evaluation.
-   * Delegates to repository if the method exists.
    */
   async getAssignees(evaluationNo: string): Promise<any[]> {
-    if (typeof (this.repository as any).findAssignees === "function") {
-      return (this.repository as any).findAssignees(evaluationNo);
-    }
-    return [];
+    return this.repository.findAssignees(evaluationNo);
   }
 
   /**
    * Update assignee for an evaluation.
-   * Delegates to repository if the method exists.
    */
   async updateAssignee(
     evaluationNo: string,
-    body: any
+    body: { stepId: string; staffId: string }
   ): Promise<any | null> {
-    if (typeof (this.repository as any).updateAssignee === "function") {
-      return (this.repository as any).updateAssignee(evaluationNo, body);
-    }
-    return null;
+    return this.repository.updateAssignee(evaluationNo, body);
   }
 }

--- a/judgesystem/backend/app/src/services/index.ts
+++ b/judgesystem/backend/app/src/services/index.ts
@@ -8,6 +8,8 @@ export {
   defaultWorkStatus,
   defaultCurrentStep,
   defaultPriority,
+  validateWorkStatus,
+  validateCurrentStep,
 } from "./evaluationService";
 
 export {

--- a/judgesystem/backend/app/src/types/index.ts
+++ b/judgesystem/backend/app/src/types/index.ts
@@ -1,0 +1,16 @@
+// Re-export shared types for backward compatibility
+export type {
+  FilterParams,
+  PaginatedResponse,
+} from "../../../shared/types/filter";
+
+export type {
+  EvaluationStatus,
+  WorkStatus,
+  CurrentStep,
+} from "../../../shared/types/evaluation";
+
+export type {
+  AnnouncementStatus,
+  BidType,
+} from "../../../shared/types/announcement";

--- a/judgesystem/backend/app/src/utils/validation.ts
+++ b/judgesystem/backend/app/src/utils/validation.ts
@@ -1,0 +1,68 @@
+import type { FilterParams } from "../../../../shared/types";
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from "../../../../shared/constants";
+
+/**
+ * Parse and validate query parameters into FilterParams.
+ * Returns a sanitized FilterParams object, stripping invalid values.
+ */
+export function parseFilterParams(query: Record<string, any>): FilterParams {
+  const params: FilterParams = {};
+
+  // Pagination
+  if (query.page !== undefined) {
+    const page = parseInt(String(query.page), 10);
+    params.page = isNaN(page) || page < 0 ? DEFAULT_PAGE : page;
+  }
+  if (query.pageSize !== undefined) {
+    const pageSize = parseInt(String(query.pageSize), 10);
+    params.pageSize =
+      isNaN(pageSize) || pageSize < 1 ? DEFAULT_PAGE_SIZE : Math.min(pageSize, 100);
+  }
+
+  // Arrays (comma-separated or already arrays)
+  const arrayFields = [
+    "statuses",
+    "workStatuses",
+    "priorities",
+    "categories",
+    "bidTypes",
+    "organizations",
+    "prefectures",
+  ] as const;
+
+  for (const field of arrayFields) {
+    const raw = query[field];
+    if (raw !== undefined && raw !== "") {
+      params[field] = Array.isArray(raw) ? raw : String(raw).split(",");
+    }
+  }
+
+  // Sort
+  if (query.sortField && typeof query.sortField === "string") {
+    params.sortField = query.sortField;
+  }
+  if (query.sortOrder === "asc" || query.sortOrder === "desc") {
+    params.sortOrder = query.sortOrder;
+  }
+
+  // Search
+  if (query.searchQuery && typeof query.searchQuery === "string") {
+    params.searchQuery = query.searchQuery.trim();
+  }
+
+  // ordererId
+  if (query.ordererId && typeof query.ordererId === "string") {
+    params.ordererId = query.ordererId;
+  }
+
+  return params;
+}
+
+/**
+ * Validate that a string is a positive integer. Returns the parsed number or null.
+ */
+export function parsePositiveInt(value: string | undefined): number | null {
+  if (!value) return null;
+  const n = parseInt(value, 10);
+  return isNaN(n) || n < 0 ? null : n;
+}

--- a/judgesystem/frontend/app/src/components/common/FilterButton.tsx
+++ b/judgesystem/frontend/app/src/components/common/FilterButton.tsx
@@ -1,0 +1,57 @@
+import { Box } from '@mui/material';
+import { colors, fontSizes, borderRadius, rightPanelColors } from '../../constants/styles';
+
+export interface FilterButtonProps {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  color?: string;
+  bgColor?: string;
+}
+
+export function FilterButton({
+  label,
+  selected,
+  onClick,
+  color,
+  bgColor,
+}: FilterButtonProps) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        position: 'relative',
+        padding: '6px 12px',
+        paddingLeft: selected ? '14px' : '12px',
+        borderRadius: borderRadius.xs,
+        fontSize: fontSizes.xs,
+        fontWeight: selected ? 600 : 500,
+        cursor: 'pointer',
+        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
+        transition: 'all 0.2s ease',
+        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
+        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
+        overflow: 'hidden',
+        ...(selected && {
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: '3px',
+            backgroundColor: color || colors.accent.blue,
+          },
+        }),
+        '&:hover': {
+          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+          color: selected ? (color || colors.text.white) : rightPanelColors.text,
+          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
+        },
+      }}
+    >
+      {label}
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/components/common/index.ts
+++ b/judgesystem/frontend/app/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export { ErrorBoundary } from './ErrorBoundary';
-export { FilterOptionButton } from './FilterOptionButton';
+export { FilterButton } from './FilterButton';
+export type { FilterButtonProps } from './FilterButton';
 export { SelectAllButton } from './SelectAllButton';
 export { CollapsibleSection } from './CollapsibleSection';
 export { CollapsiblePanel } from './CollapsiblePanel';

--- a/judgesystem/frontend/app/src/hooks/index.ts
+++ b/judgesystem/frontend/app/src/hooks/index.ts
@@ -1,0 +1,15 @@
+export { useAnnouncementDetail } from './useAnnouncementDetail';
+export { usePartnerDetail } from './usePartnerDetail';
+
+export type {
+  SortOption as AnnouncementSortOption,
+  CompanySortOption,
+  PreviewState,
+  RelatedFilterState,
+  CompanyFilterState,
+} from './useAnnouncementDetail';
+
+export type {
+  SortOption as PartnerSortOption,
+  ProjectFilterState,
+} from './usePartnerDetail';

--- a/judgesystem/frontend/app/src/hooks/useAnnouncementDetail.ts
+++ b/judgesystem/frontend/app/src/hooks/useAnnouncementDetail.ts
@@ -1,0 +1,403 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { resolveAnnouncementStatus, resolveBidType } from '../components/announcement';
+import { getOrganizationGroup } from '../constants/organizations';
+import { getApiUrl } from '../config/api';
+import type { AnnouncementDetail, ProgressingCompany } from '../components/announcement';
+import type { EvaluationStatus, WorkStatus, CompanyPriority, DocumentOcr } from '../types';
+import type { AnnouncementStatus } from '../types/announcement';
+
+// -- Types --
+
+export type SortOption = 'deadline_asc' | 'deadline_desc' | 'publish_asc' | 'publish_desc' | 'status_asc' | 'status_desc' | 'prefecture_asc' | 'prefecture_desc';
+export type CompanySortOption = 'priority_asc' | 'priority_desc' | 'workStatus_asc' | 'workStatus_desc' | 'company_asc' | 'company_desc' | 'evaluationStatus_asc' | 'evaluationStatus_desc';
+export type PreviewState = { url?: string; loading: boolean; error?: string };
+
+export interface RelatedFilterState {
+  statuses: AnnouncementStatus[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+  organizations: string[];
+}
+
+export interface CompanyFilterState {
+  evaluationStatuses: EvaluationStatus[];
+  workStatuses: ('in_progress' | 'completed')[];
+  priorities: (1 | 2 | 3 | 4 | 5)[];
+}
+
+// -- Constants --
+
+const STATUS_ORDER: Record<AnnouncementStatus, number> = {
+  upcoming: 0, ongoing: 1, awaiting_result: 2, closed: 3,
+};
+const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
+  all_met: 0, other_only_unmet: 1, unmet: 2,
+};
+const WORK_STATUS_ORDER: Record<Extract<WorkStatus, 'in_progress' | 'completed'>, number> = {
+  in_progress: 0, completed: 1,
+};
+const PRIORITY_ORDER: Record<CompanyPriority, number> = { 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 };
+const NAV_TRACKING_KEY = 'lastVisitedPath';
+
+const normalizePriority = (value: number): CompanyPriority => {
+  const rounded = Math.round(value);
+  return ([1, 2, 3, 4, 5].includes(rounded) ? rounded : 1) as CompanyPriority;
+};
+const normalizeWorkStatus = (value: string): Extract<WorkStatus, 'in_progress' | 'completed'> =>
+  value === 'completed' ? 'completed' : 'in_progress';
+
+const getStatusOrderValue = (status?: string) =>
+  STATUS_ORDER[resolveAnnouncementStatus(status)] ?? 0;
+
+// -- Hook --
+
+export function useAnnouncementDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Core state
+  const [activeTab, setActiveTab] = useState(0);
+  const [announcement, setAnnouncement] = useState<AnnouncementDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Related announcements
+  const [relatedSearchQuery, setRelatedSearchQuery] = useState('');
+  const [relatedSortOption, setRelatedSortOption] = useState<SortOption | null>(null);
+  const [relatedFilters, setRelatedFilters] = useState<RelatedFilterState>({
+    statuses: [], bidTypes: [], categories: [], prefectures: [], organizations: [],
+  });
+  const [relatedPage, setRelatedPage] = useState(0);
+  const relatedPageSize = 25;
+
+  // Progressing companies
+  const [companySearchQuery, setCompanySearchQuery] = useState('');
+  const [companySortOption, setCompanySortOption] = useState<CompanySortOption | null>(null);
+  const [companyFilters, setCompanyFilters] = useState<CompanyFilterState>({
+    evaluationStatuses: [], workStatuses: [], priorities: [],
+  });
+  const [companyPage, setCompanyPage] = useState(0);
+  const companyPageSize = 25;
+  const [progressingCompanies, setProgressingCompanies] = useState<ProgressingCompany[]>([]);
+  const [isProgressingLoading, setIsProgressingLoading] = useState(false);
+
+  // Document preview
+  const [documentPreviewState, setDocumentPreviewState] = useState<Record<string, PreviewState>>({});
+  const previewUrlRef = useRef<Record<string, string>>({});
+  const documentPreviewStateRef = useRef<Record<string, PreviewState>>({});
+  const previewFetchControllersRef = useRef<Record<string, AbortController>>({});
+
+  // Nav tracking
+  useEffect(() => {
+    try { sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname); } catch { /* ignore */ }
+  }, [location.pathname]);
+
+  // Preview cleanup helpers
+  const abortAllPreviewFetches = useCallback(() => {
+    Object.values(previewFetchControllersRef.current).forEach(c => c.abort());
+    previewFetchControllersRef.current = {};
+  }, []);
+
+  const revokeAllPreviewUrls = useCallback(() => {
+    Object.values(previewUrlRef.current).forEach(url => { if (url) URL.revokeObjectURL(url); });
+    previewUrlRef.current = {};
+  }, []);
+
+  const resetPreviewState = useCallback(() => {
+    abortAllPreviewFetches();
+    revokeAllPreviewUrls();
+    setDocumentPreviewState(() => { documentPreviewStateRef.current = {}; return {}; });
+  }, [abortAllPreviewFetches, revokeAllPreviewUrls]);
+
+  useEffect(() => () => { abortAllPreviewFetches(); revokeAllPreviewUrls(); }, [abortAllPreviewFetches, revokeAllPreviewUrls]);
+  useEffect(() => { resetPreviewState(); }, [announcement?.announcementNo, resetPreviewState]);
+
+  // Fetch announcement
+  useEffect(() => {
+    const fetchAnnouncement = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const announcementNo = id.startsWith('ann-') ? id.substring(4) : id;
+        const response = await fetch(getApiUrl(`/api/announcements/${announcementNo}`));
+        if (!response.ok) throw new Error(`Failed to fetch announcement: ${response.status}`);
+        setAnnouncement(await response.json());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnnouncement();
+  }, [id]);
+
+  // Load PDF preview
+  const loadPdfPreview = useCallback(
+    async (documentId: number, options?: { force?: boolean }) => {
+      if (!announcement?.announcementNo) return;
+      const docKey = String(documentId);
+      const forceReload = options?.force ?? false;
+      const currentState = documentPreviewStateRef.current[docKey];
+      if (!forceReload && (currentState?.loading || currentState?.url)) return;
+
+      if (forceReload && previewUrlRef.current[docKey]) {
+        URL.revokeObjectURL(previewUrlRef.current[docKey]);
+        delete previewUrlRef.current[docKey];
+      }
+
+      const existingController = previewFetchControllersRef.current[docKey];
+      if (existingController) existingController.abort();
+
+      const controller = new AbortController();
+      previewFetchControllersRef.current[docKey] = controller;
+
+      setDocumentPreviewState(prev => {
+        const nextState = { ...prev, [docKey]: { loading: true } };
+        documentPreviewStateRef.current = nextState;
+        return nextState;
+      });
+
+      try {
+        const response = await fetch(
+          getApiUrl(`/api/announcements/${announcement.announcementNo}/documents/${docKey}/preview`),
+          { signal: controller.signal }
+        );
+        if (!response.ok) throw new Error(`Failed to fetch preview (${response.status})`);
+        const blob = await response.blob();
+        if (controller.signal.aborted) return;
+
+        const objectUrl = URL.createObjectURL(blob);
+        if (previewUrlRef.current[docKey]) URL.revokeObjectURL(previewUrlRef.current[docKey]);
+        previewUrlRef.current[docKey] = objectUrl;
+
+        setDocumentPreviewState(prev => {
+          const nextState = { ...prev, [docKey]: { loading: false, url: objectUrl } };
+          documentPreviewStateRef.current = nextState;
+          return nextState;
+        });
+      } catch (err) {
+        if ((err instanceof DOMException && err.name === 'AbortError') || controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : 'PDFプレビューの取得に失敗しました';
+        setDocumentPreviewState(prev => {
+          const nextState = { ...prev, [docKey]: { loading: false, error: message } };
+          documentPreviewStateRef.current = nextState;
+          return nextState;
+        });
+      } finally {
+        if (previewFetchControllersRef.current[docKey] === controller) {
+          delete previewFetchControllersRef.current[docKey];
+        }
+      }
+    },
+    [announcement?.announcementNo]
+  );
+
+  // Auto-load first PDF
+  useEffect(() => {
+    if (!announcement?.documents) return;
+    const firstPdfDoc = announcement.documents.find(
+      (doc: DocumentOcr) => doc.fileFormat && doc.fileFormat.toLowerCase() === 'pdf'
+    );
+    if (firstPdfDoc) loadPdfPreview(firstPdfDoc.id);
+  }, [announcement?.documents, loadPdfPreview]);
+
+  // Fetch progressing companies
+  useEffect(() => {
+    if (!announcement?.announcementNo) { setProgressingCompanies([]); return; }
+    let isCancelled = false;
+    const fetchProgressingCompanies = async () => {
+      setIsProgressingLoading(true);
+      try {
+        const response = await fetch(
+          getApiUrl(`/api/announcements/${announcement.announcementNo}/progressing-companies`)
+        );
+        if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+        const data = await response.json();
+        if (isCancelled) return;
+        setProgressingCompanies(
+          Array.isArray(data) ? data.map((row: any) => ({
+            companyId: String(row.companyId ?? ''),
+            companyName: row.companyName ?? '',
+            branchId: String(row.branchId ?? ''),
+            branchName: row.branchName ?? '',
+            priority: normalizePriority(Number(row.priority ?? 1)),
+            workStatus: normalizeWorkStatus(row.workStatus ?? ''),
+            evaluationId: String(row.evaluationId ?? ''),
+            evaluationStatus: (row.evaluationStatus ?? 'unmet') as EvaluationStatus,
+          })) : []
+        );
+      } catch (err) {
+        console.error('Failed to fetch progressing companies:', err);
+        if (!isCancelled) setProgressingCompanies([]);
+      } finally {
+        if (!isCancelled) setIsProgressingLoading(false);
+      }
+    };
+    fetchProgressingCompanies();
+    return () => { isCancelled = true; };
+  }, [announcement?.announcementNo]);
+
+  // Search handlers
+  const handleRelatedSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setRelatedSearchQuery(e.target.value);
+    setRelatedPage(0);
+  }, []);
+
+  const handleCompanySearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setCompanySearchQuery(e.target.value);
+    setCompanyPage(0);
+  }, []);
+
+  // Fetch related announcements from API
+  const [baseRelatedAnnouncements, setBaseRelatedAnnouncements] = useState<any[]>([]);
+  useEffect(() => {
+    if (!announcement?.announcementNo) { setBaseRelatedAnnouncements([]); return; }
+    let isCancelled = false;
+    const fetchRelated = async () => {
+      try {
+        const response = await fetch(
+          getApiUrl(`/api/announcements/${announcement.announcementNo}/related`)
+        );
+        if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+        const data = await response.json();
+        if (!isCancelled) setBaseRelatedAnnouncements(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error('Failed to fetch related announcements:', err);
+        if (!isCancelled) setBaseRelatedAnnouncements([]);
+      }
+    };
+    fetchRelated();
+    return () => { isCancelled = true; };
+  }, [announcement?.announcementNo]);
+
+  const filteredRelatedAnnouncements = useMemo(() => {
+    let filtered = baseRelatedAnnouncements;
+
+    if (relatedSearchQuery) {
+      const query = relatedSearchQuery.toLowerCase();
+      filtered = filtered.filter((a) =>
+        a.title.toLowerCase().includes(query) ||
+        a.category.toLowerCase().includes(query) ||
+        a.workLocation.toLowerCase().includes(query)
+      );
+    }
+
+    filtered = filtered.filter((a) => {
+      if (relatedFilters.statuses.length > 0 && !relatedFilters.statuses.includes(resolveAnnouncementStatus(a.status as string | undefined))) return false;
+      if (relatedFilters.bidTypes.length > 0 && (!a.bidType || !relatedFilters.bidTypes.includes(a.bidType))) return false;
+      if (relatedFilters.categories.length > 0 && !relatedFilters.categories.includes(a.category)) return false;
+      if (relatedFilters.prefectures.length > 0) {
+        const prefecture = a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '';
+        if (!relatedFilters.prefectures.includes(prefecture)) return false;
+      }
+      if (relatedFilters.organizations.length > 0) {
+        if (!relatedFilters.organizations.includes(getOrganizationGroup(a.organization))) return false;
+      }
+      return true;
+    });
+
+    if (!relatedSortOption) return filtered;
+    return [...filtered].sort((a, b) => {
+      switch (relatedSortOption) {
+        case 'deadline_asc': return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+        case 'deadline_desc': return new Date(b.deadline).getTime() - new Date(a.deadline).getTime();
+        case 'publish_asc': return new Date(a.publishDate).getTime() - new Date(b.publishDate).getTime();
+        case 'publish_desc': return new Date(b.publishDate).getTime() - new Date(a.publishDate).getTime();
+        case 'status_asc': return getStatusOrderValue(a.status as string | undefined) - getStatusOrderValue(b.status as string | undefined);
+        case 'status_desc': return getStatusOrderValue(b.status as string | undefined) - getStatusOrderValue(a.status as string | undefined);
+        case 'prefecture_asc': return (a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '').localeCompare(b.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '', 'ja');
+        case 'prefecture_desc': return (b.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '').localeCompare(a.workLocation?.match(/^(.+?[都道府県])/)?.[1] || '', 'ja');
+        default: return 0;
+      }
+    });
+  }, [baseRelatedAnnouncements, relatedSearchQuery, relatedFilters, relatedSortOption]);
+
+  const paginatedRelatedAnnouncements = useMemo(() => {
+    const start = relatedPage * relatedPageSize;
+    return filteredRelatedAnnouncements.slice(start, start + relatedPageSize);
+  }, [filteredRelatedAnnouncements, relatedPage]);
+
+  // Company filtering
+  const filteredProgressingCompanies = useMemo<ProgressingCompany[]>(() => {
+    let filtered = progressingCompanies;
+
+    if (companySearchQuery) {
+      const query = companySearchQuery.toLowerCase();
+      filtered = filtered.filter(c =>
+        c.companyName.toLowerCase().includes(query) || c.branchName.toLowerCase().includes(query)
+      );
+    }
+
+    filtered = filtered.filter(c => {
+      if (companyFilters.evaluationStatuses.length > 0 && !companyFilters.evaluationStatuses.includes(c.evaluationStatus)) return false;
+      if (companyFilters.workStatuses.length > 0 && !companyFilters.workStatuses.includes(c.workStatus)) return false;
+      if (companyFilters.priorities.length > 0 && !companyFilters.priorities.includes(c.priority)) return false;
+      return true;
+    });
+
+    if (!companySortOption) return filtered;
+    return [...filtered].sort((a, b) => {
+      switch (companySortOption) {
+        case 'priority_asc': return PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority];
+        case 'priority_desc': return PRIORITY_ORDER[b.priority] - PRIORITY_ORDER[a.priority];
+        case 'evaluationStatus_asc': return EVALUATION_STATUS_ORDER[a.evaluationStatus] - EVALUATION_STATUS_ORDER[b.evaluationStatus];
+        case 'evaluationStatus_desc': return EVALUATION_STATUS_ORDER[b.evaluationStatus] - EVALUATION_STATUS_ORDER[a.evaluationStatus];
+        case 'workStatus_asc': return WORK_STATUS_ORDER[a.workStatus] - WORK_STATUS_ORDER[b.workStatus];
+        case 'workStatus_desc': return WORK_STATUS_ORDER[b.workStatus] - WORK_STATUS_ORDER[a.workStatus];
+        case 'company_asc': return a.companyName.localeCompare(b.companyName, 'ja');
+        case 'company_desc': return b.companyName.localeCompare(a.companyName, 'ja');
+        default: return 0;
+      }
+    });
+  }, [progressingCompanies, companySearchQuery, companyFilters, companySortOption]);
+
+  const paginatedProgressingCompanies = useMemo<ProgressingCompany[]>(() => {
+    const start = companyPage * companyPageSize;
+    return filteredProgressingCompanies.slice(start, start + companyPageSize);
+  }, [filteredProgressingCompanies, companyPage, companyPageSize]);
+
+  // Clear handlers
+  const clearRelated = useCallback(() => {
+    setRelatedSearchQuery('');
+    setRelatedSortOption(null);
+    setRelatedFilters({ statuses: [], bidTypes: [], categories: [], prefectures: [], organizations: [] });
+    setRelatedPage(0);
+  }, []);
+
+  const clearCompany = useCallback(() => {
+    setCompanySearchQuery('');
+    setCompanySortOption(null);
+    setCompanyFilters({ evaluationStatuses: [], workStatuses: [], priorities: [] });
+    setCompanyPage(0);
+  }, []);
+
+  return {
+    id, navigate, activeTab, setActiveTab,
+    announcement, loading, error,
+    // Related
+    relatedSearchQuery, handleRelatedSearchChange,
+    relatedSortOption, setRelatedSortOption,
+    relatedFilters, setRelatedFilters,
+    relatedPage, setRelatedPage, relatedPageSize,
+    baseRelatedAnnouncements,
+    filteredRelatedAnnouncements,
+    paginatedRelatedAnnouncements,
+    clearRelated,
+    // Companies
+    companySearchQuery, handleCompanySearchChange,
+    companySortOption, setCompanySortOption,
+    companyFilters, setCompanyFilters,
+    companyPage, setCompanyPage, companyPageSize,
+    progressingCompanies,
+    isProgressingLoading,
+    filteredProgressingCompanies,
+    paginatedProgressingCompanies,
+    clearCompany,
+    // Documents
+    documentPreviewState, loadPdfPreview,
+  };
+}

--- a/judgesystem/frontend/app/src/hooks/usePartnerDetail.ts
+++ b/judgesystem/frontend/app/src/hooks/usePartnerDetail.ts
@@ -1,0 +1,172 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { getApiUrl } from '../config/api';
+import type { PastProject } from '../types/partner';
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../types';
+
+// -- Types --
+
+export type SortOption =
+  | 'deadline_asc' | 'deadline_desc'
+  | 'evaluationStatus_asc' | 'evaluationStatus_desc'
+  | 'workStatus_asc' | 'workStatus_desc'
+  | 'priority_asc' | 'priority_desc'
+  | 'prefecture_asc' | 'prefecture_desc'
+  | 'evaluatedAt_asc' | 'evaluatedAt_desc';
+
+export interface ProjectFilterState {
+  workStatuses: WorkStatus[];
+  evaluationStatuses: EvaluationStatus[];
+  priorities: CompanyPriority[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+  organizations: string[];
+}
+
+// -- Constants --
+
+const WORK_STATUS_ORDER: Record<WorkStatus, number> = {
+  not_started: 0, in_progress: 1, completed: 2,
+};
+const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
+  all_met: 0, other_only_unmet: 1, unmet: 2,
+};
+const NAV_TRACKING_KEY = 'lastVisitedPath';
+
+const EMPTY_FILTERS: ProjectFilterState = {
+  workStatuses: [], evaluationStatuses: [], priorities: [],
+  bidTypes: [], categories: [], prefectures: [], organizations: [],
+};
+
+// -- Hook --
+
+export function usePartnerDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [activeTab, setActiveTab] = useState(0);
+  const [partner, setPartner] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Project list state
+  const [projectSearchQuery, setProjectSearchQuery] = useState('');
+  const [projectPage, setProjectPage] = useState(0);
+  const projectPageSize = 25;
+  const [sortOption, setSortOption] = useState<SortOption | null>(null);
+  const [filters, setFilters] = useState<ProjectFilterState>(EMPTY_FILTERS);
+
+  // Nav tracking
+  useEffect(() => {
+    try { sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname); } catch { /* ignore */ }
+  }, [location.pathname]);
+
+  // Fetch partner
+  useEffect(() => {
+    const fetchPartner = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(getApiUrl(`/api/partners/${id}`));
+        if (!response.ok) throw new Error(`Failed to fetch partner: ${response.status}`);
+        setPartner(await response.json());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPartner();
+  }, [id]);
+
+  // Search handler
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setProjectSearchQuery(e.target.value);
+    setProjectPage(0);
+  }, []);
+
+  // Filtered projects
+  const filteredProjects = useMemo((): PastProject[] => {
+    if (!partner) return [];
+    const pastProjects = partner.pastProjects || [];
+    if (!Array.isArray(pastProjects)) return [];
+
+    let filtered = pastProjects;
+    if (projectSearchQuery) {
+      const query = projectSearchQuery.toLowerCase();
+      filtered = filtered.filter((p: PastProject) =>
+        p.announcementTitle.toLowerCase().includes(query) ||
+        p.category.toLowerCase().includes(query) ||
+        p.prefecture.toLowerCase().includes(query) ||
+        p.branchName.toLowerCase().includes(query)
+      );
+    }
+
+    filtered = filtered.filter((p: PastProject) => {
+      if (filters.workStatuses.length > 0 && !filters.workStatuses.includes(p.workStatus)) return false;
+      if (filters.evaluationStatuses.length > 0 && !filters.evaluationStatuses.includes(p.evaluationStatus)) return false;
+      if (filters.priorities.length > 0) {
+        if (p.priority == null || !filters.priorities.includes(p.priority as CompanyPriority)) return false;
+      }
+      if (filters.bidTypes.length > 0 && (!p.bidType || !filters.bidTypes.includes(p.bidType))) return false;
+      if (filters.categories.length > 0 && !filters.categories.includes(p.category)) return false;
+      if (filters.prefectures.length > 0 && !filters.prefectures.includes(p.prefecture)) return false;
+      if (filters.organizations.length > 0 && !filters.organizations.includes(p.organization)) return false;
+      return true;
+    });
+
+    if (!sortOption) return filtered;
+    return [...filtered].sort((a, b) => {
+      switch (sortOption) {
+        case 'deadline_asc': return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+        case 'deadline_desc': return new Date(b.deadline).getTime() - new Date(a.deadline).getTime();
+        case 'evaluationStatus_asc': return EVALUATION_STATUS_ORDER[a.evaluationStatus as EvaluationStatus] - EVALUATION_STATUS_ORDER[b.evaluationStatus as EvaluationStatus];
+        case 'evaluationStatus_desc': return EVALUATION_STATUS_ORDER[b.evaluationStatus as EvaluationStatus] - EVALUATION_STATUS_ORDER[a.evaluationStatus as EvaluationStatus];
+        case 'workStatus_asc': return WORK_STATUS_ORDER[a.workStatus as WorkStatus] - WORK_STATUS_ORDER[b.workStatus as WorkStatus];
+        case 'workStatus_desc': return WORK_STATUS_ORDER[b.workStatus as WorkStatus] - WORK_STATUS_ORDER[a.workStatus as WorkStatus];
+        case 'priority_asc': return (a.priority ?? 99) - (b.priority ?? 99);
+        case 'priority_desc': return (b.priority ?? 0) - (a.priority ?? 0);
+        case 'prefecture_asc': return a.prefecture.localeCompare(b.prefecture, 'ja');
+        case 'prefecture_desc': return b.prefecture.localeCompare(a.prefecture, 'ja');
+        case 'evaluatedAt_asc': return new Date(a.evaluatedAt).getTime() - new Date(b.evaluatedAt).getTime();
+        case 'evaluatedAt_desc': return new Date(b.evaluatedAt).getTime() - new Date(a.evaluatedAt).getTime();
+        default: return 0;
+      }
+    });
+  }, [partner, projectSearchQuery, filters, sortOption]);
+
+  const paginatedProjects = useMemo(() => {
+    const start = projectPage * projectPageSize;
+    return filteredProjects.slice(start, start + projectPageSize);
+  }, [filteredProjects, projectPage]);
+
+  // Safe partner (with defaults)
+  const safePartner = partner ? {
+    ...partner,
+    branches: partner.branches || [],
+    categories: partner.categories || [],
+    pastProjects: partner.pastProjects || [],
+    qualifications: partner.qualifications || { unified: [], orderers: [] },
+  } : null;
+
+  const clearAll = useCallback(() => {
+    setProjectSearchQuery('');
+    setSortOption(null);
+    setFilters(EMPTY_FILTERS);
+    setProjectPage(0);
+  }, []);
+
+  return {
+    id, navigate, activeTab, setActiveTab,
+    partner: safePartner, loading, error,
+    projectSearchQuery, handleSearchChange,
+    projectPage, setProjectPage, projectPageSize,
+    sortOption, setSortOption,
+    filters, setFilters,
+    filteredProjects, paginatedProjects,
+    clearAll,
+  };
+}

--- a/judgesystem/frontend/app/src/pages/AnnouncementDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/AnnouncementDetailPage.tsx
@@ -18,7 +18,7 @@ import { categories } from '../constants/categories';
 import { bidTypes } from '../constants/bidType';
 import { prefecturesByRegion } from '../constants/prefectures';
 import { organizationGroupsByRegion, getOrganizationGroup } from '../constants/organizations';
-import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
+import { NotFoundView, FloatingBackButton, ScrollToTopButton, FilterButton } from '../components/common';
 import { CustomPagination } from '../components/bid';
 import { RightSidePanel } from '../components/layout';
 import {
@@ -145,60 +145,6 @@ const normalizePriority = (value: number): CompanyPriority => {
 const normalizeWorkStatus = (value: string): Extract<WorkStatus, 'in_progress' | 'completed'> => {
   return value === 'completed' ? 'completed' : 'in_progress';
 };
-
-// フィルターボタン
-function FilterButton({
-  label,
-  selected,
-  onClick,
-  color,
-  bgColor,
-}: {
-  label: string;
-  selected: boolean;
-  onClick: () => void;
-  color?: string;
-  bgColor?: string;
-}) {
-  return (
-    <Box
-      component="button"
-      onClick={onClick}
-      sx={{
-        position: 'relative',
-        padding: '6px 12px',
-        paddingLeft: selected ? '14px' : '12px',
-        borderRadius: borderRadius.xs,
-        fontSize: fontSizes.xs,
-        fontWeight: selected ? 600 : 500,
-        cursor: 'pointer',
-        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
-        transition: 'all 0.2s ease',
-        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
-        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
-        overflow: 'hidden',
-        ...(selected && {
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            width: '3px',
-            backgroundColor: color || colors.accent.blue,
-          },
-        }),
-        '&:hover': {
-          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-          color: selected ? (color || colors.text.white) : rightPanelColors.text,
-          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
-        },
-      }}
-    >
-      {label}
-    </Box>
-  );
-}
 
 // 関連案件用表示条件パネル
 interface RelatedConditionsPanelProps {

--- a/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
@@ -27,7 +27,7 @@ import { categories } from '../constants/categories';
 import { bidTypes } from '../constants/bidType';
 import { prefecturesByRegion } from '../constants/prefectures';
 import { organizationGroupsByRegion } from '../constants/organizations';
-import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
+import { NotFoundView, FloatingBackButton, ScrollToTopButton, FilterButton } from '../components/common';
 import { RightSidePanel } from '../components/layout';
 import { PartnerBasicInfo, PartnerQualifications, PartnerHistory } from '../components/partner';
 import { useSidebar } from '../contexts/SidebarContext';
@@ -95,60 +95,6 @@ const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
   other_only_unmet: 1,
   unmet: 2,
 };
-
-// フィルターボタン
-function FilterButton({
-  label,
-  selected,
-  onClick,
-  color,
-  bgColor,
-}: {
-  label: string;
-  selected: boolean;
-  onClick: () => void;
-  color?: string;
-  bgColor?: string;
-}) {
-  return (
-    <Box
-      component="button"
-      onClick={onClick}
-      sx={{
-        position: 'relative',
-        padding: '6px 12px',
-        paddingLeft: selected ? '14px' : '12px',
-        borderRadius: borderRadius.xs,
-        fontSize: fontSizes.xs,
-        fontWeight: selected ? 600 : 500,
-        cursor: 'pointer',
-        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
-        transition: 'all 0.2s ease',
-        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
-        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
-        overflow: 'hidden',
-        ...(selected && {
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            width: '3px',
-            backgroundColor: color || colors.accent.blue,
-          },
-        }),
-        '&:hover': {
-          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-          color: selected ? (color || colors.text.white) : rightPanelColors.text,
-          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
-        },
-      }}
-    >
-      {label}
-    </Box>
-  );
-}
 
 // 案件用表示条件パネル
 interface ProjectConditionsPanelProps {

--- a/judgesystem/shared/constants.ts
+++ b/judgesystem/shared/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE = 0;
+export const DEFAULT_PAGE_SIZE = 25;

--- a/judgesystem/shared/types/announcement.ts
+++ b/judgesystem/shared/types/announcement.ts
@@ -1,0 +1,45 @@
+export type AnnouncementStatus = "upcoming" | "ongoing" | "awaiting_result" | "closed";
+
+export type BidType =
+  | "general-competitive-bidding"
+  | "design-competition"
+  | "one-off"
+  | "proposal"
+  | "negotiated-contract"
+  | "unknown";
+
+// -- Concrete response types --
+
+export interface AnnouncementListItem {
+  id: string;
+  announcementNo: number;
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  publishDate: string;
+  deadline: string;
+}
+
+export interface Department {
+  postalCode: string;
+  address: string;
+  name: string;
+  contactPerson: string;
+  phone: string;
+  fax: string;
+  email: string;
+}
+
+export interface DocumentMeta {
+  id: string;
+  type: string;
+  title: string;
+  fileFormat: string;
+  pageCount: number | null;
+  extractedAt: string | null;
+  url: string;
+  markdown_path?: string;
+  content?: string;
+}

--- a/judgesystem/shared/types/evaluation.ts
+++ b/judgesystem/shared/types/evaluation.ts
@@ -1,0 +1,78 @@
+export type EvaluationStatus = "all_met" | "other_only_unmet" | "unmet";
+
+export type WorkStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "on_hold"
+  | "cancelled";
+
+export type CurrentStep =
+  | "judgment"
+  | "document_review"
+  | "field_survey"
+  | "final_review";
+
+export const VALID_WORK_STATUSES: ReadonlySet<string> = new Set([
+  "not_started",
+  "in_progress",
+  "completed",
+  "on_hold",
+  "cancelled",
+]);
+
+export const VALID_CURRENT_STEPS: ReadonlySet<string> = new Set([
+  "judgment",
+  "document_review",
+  "field_survey",
+  "final_review",
+]);
+
+// -- Concrete response types --
+
+export interface EvaluationListItem {
+  id: string;
+  evaluationNo: string;
+  announcement: {
+    title: string;
+    organization: string;
+    category: string;
+    bidType: string;
+    deadline: string;
+    workLocation: string;
+    estimatedAmountMin: number | null;
+    estimatedAmountMax: number | null;
+  };
+  company: { name: string };
+  branch: {
+    id: string;
+    name: string;
+    address: string;
+    phone: string;
+    email: string;
+    fax: string;
+    postalCode: string;
+  };
+  finalStatus: boolean;
+  requirementIneligibility: boolean;
+  requirementGradeItem: boolean;
+  requirementLocation: boolean;
+  requirementExperience: boolean;
+  requirementTechnician: boolean;
+  requirementOther: boolean;
+  workStatus: WorkStatus | null;
+  currentStep: CurrentStep | null;
+  evaluatedAt: string | null;
+}
+
+export interface StatusCounts {
+  all_met: number;
+  other_only_unmet: number;
+  unmet: number;
+}
+
+export interface AssigneeRecord {
+  stepId: string;
+  staffId: string;
+  assignedAt: string;
+}

--- a/judgesystem/shared/types/filter.ts
+++ b/judgesystem/shared/types/filter.ts
@@ -1,0 +1,22 @@
+export interface FilterParams {
+  page?: number;
+  pageSize?: number;
+  statuses?: string[];
+  workStatuses?: string[];
+  priorities?: string[];
+  categories?: string[];
+  bidTypes?: string[];
+  organizations?: string[];
+  prefectures?: string[];
+  searchQuery?: string;
+  sortField?: string;
+  sortOrder?: "asc" | "desc";
+  ordererId?: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+}

--- a/judgesystem/shared/types/index.ts
+++ b/judgesystem/shared/types/index.ts
@@ -1,0 +1,23 @@
+export type {
+  EvaluationStatus,
+  WorkStatus,
+  CurrentStep,
+  EvaluationListItem,
+  StatusCounts,
+  AssigneeRecord,
+} from "./evaluation";
+
+export { VALID_WORK_STATUSES, VALID_CURRENT_STEPS } from "./evaluation";
+
+export type {
+  AnnouncementStatus,
+  BidType,
+  AnnouncementListItem,
+  Department,
+  DocumentMeta,
+} from "./announcement";
+
+export type {
+  FilterParams,
+  PaginatedResponse,
+} from "./filter";


### PR DESCRIPTION
## Summary

Miyabi パイプラインで生成された judgesystem の改善コードをまとめて PR 化。
IssueAgent のラベル名不一致により自動パイプラインが停止していたため、手動で PR を作成。

### 変更内容
- **#15** フロントエンドページコンポーネントの分割（hooks 抽出, FilterButton 共通化）
- **#16** Service 層の純粋関数にユニットテスト追加
- **#17** Express ルーターをドメインごとに分割
- **#18** バックエンド・フロントエンド間の型定義共有パッケージ作成
- **#19** 環境変数のバリデーションとスキーマ定義を追加
- **#20** AnnouncementRepository に getDocumentFile() 実装
- **#21** ルートハンドラにリクエストバリデーション追加
- **#22** Service/Repository 層の戻り値型を any から具体型に変更
- **#23** Repository の動的メソッド呼び出しをインターフェースに置換
- **#24** FilterButton コンポーネントの重複を解消
- **#25** 関連案件 API エンドポイントの実装
- **#26** EvaluationRepository の未使用メソッド整理と getStatusCounts 実装
- **#27** ページネーション定数と API パラメータ命名の統一

Closes #15, Closes #16, Closes #17, Closes #18, Closes #19
Closes #20, Closes #21, Closes #22, Closes #23, Closes #24
Closes #25, Closes #26, Closes #27

## Test plan
- [ ] TypeScript 型チェック通過
- [ ] ユニットテスト（Service 層）パス
- [ ] judgesystem アプリの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)