### PR TITLE
fix(security): timing-safe API key比較 + env config統一

### DIFF
--- a/judgesystem/backend/app/src/middleware/auth.ts
+++ b/judgesystem/backend/app/src/middleware/auth.ts
@@ -1,4 +1,6 @@
+import crypto from "crypto";
 import { Request, Response, NextFunction } from "express";
+import { env } from "../config/env";
 
 /**
  * API Key authentication middleware.
@@ -14,7 +16,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
     return next();
   }
 
-  const apiKey = process.env.API_KEY;
+  const apiKey = env.API_KEY;
   const isWriteOperation = ["POST", "PATCH", "PUT", "DELETE"].includes(req.method);
 
   // If no API_KEY configured: dev mode
@@ -41,7 +43,9 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
   }
 
   const token = authHeader.substring(7);
-  if (token !== apiKey) {
+  const tokenBuf = Buffer.from(token);
+  const apiKeyBuf = Buffer.from(apiKey);
+  if (tokenBuf.length !== apiKeyBuf.length || !crypto.timingSafeEqual(tokenBuf, apiKeyBuf)) {
     res.status(401).json({
       error: "Invalid API key",
       code: "UNAUTHORIZED",


### PR DESCRIPTION
## Summary
- API Key比較を `===` から `crypto.timingSafeEqual` に変更し、タイミング攻撃を防止 (#44)
- `process.env.API_KEY` を集約された `env.API_KEY` に統一 (#45)
- バッファ長の不一致時のハンドリングを追加

## 変更ファイル
- `judgesystem/backend/app/src/middleware/auth.ts`

## Closes
Closes #44, Closes #45

## Test plan
- [ ] API Key認証が正常に動作することを確認
- [ ] 不正なAPI Keyで401が返ることを確認
- [ ] API Key未設定時のdevモード動作を確認

🤖 Generated with [Miyabi Water Spider](https://github.com/takahiro-shimizu-1/my-app)