### PR TITLE
fix(frontend): 型インポートパス '../types' を作成

### DIFF
--- a/judgesystem/frontend/app/src/types/announcement.ts
+++ b/judgesystem/frontend/app/src/types/announcement.ts
@@ -1,0 +1,18 @@
+/**
+ * Announcement-specific type definitions.
+ *
+ * Re-exported here so that consumers can import from
+ * `../types/announcement` for domain-specific types.
+ */
+
+/** Lifecycle status of an announcement. */
+export type AnnouncementStatus = 'upcoming' | 'ongoing' | 'awaiting_result' | 'closed';
+
+/** Bid type classification. */
+export type BidType =
+  | 'general-competitive-bidding'
+  | 'design-competition'
+  | 'one-off'
+  | 'proposal'
+  | 'negotiated-contract'
+  | 'unknown';

--- a/judgesystem/frontend/app/src/types/index.ts
+++ b/judgesystem/frontend/app/src/types/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Frontend type definitions for the Judge System.
+ *
+ * These types are used across pages, hooks, and components.
+ * They are defined here as the single source of truth for
+ * the frontend application.
+ */
+
+/** Evaluation status of a company against announcement requirements. */
+export type EvaluationStatus = 'all_met' | 'other_only_unmet' | 'unmet';
+
+/** Work progress status. */
+export type WorkStatus = 'not_started' | 'in_progress' | 'completed' | 'on_hold' | 'cancelled';
+
+/** Step identifier for multi-step evaluation flows. */
+export type CurrentStep = 'judgment' | 'document_review' | 'field_survey' | 'final_review';
+
+/** Company priority ranking (1 = highest, 5 = lowest). */
+export type CompanyPriority = 1 | 2 | 3 | 4 | 5;
+
+/** OCR-extracted document metadata attached to an announcement. */
+export interface DocumentOcr {
+  id: number;
+  type: string;
+  title: string;
+  fileFormat: string;
+  pageCount: number | null;
+  extractedAt: string | null;
+  url: string;
+  markdown_path?: string;
+  content?: string;
+}
+
+/** Announcement summary used in list views and detail pages. */
+export interface Announcement {
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  publishDate: string;
+  deadline: string;
+  estimatedAmountMin: number | null;
+  estimatedAmountMax: number | null;
+  documents?: DocumentOcr[];
+}

--- a/judgesystem/frontend/app/src/types/partner.ts
+++ b/judgesystem/frontend/app/src/types/partner.ts
@@ -1,0 +1,24 @@
+/**
+ * Partner-specific type definitions.
+ *
+ * Used by PartnerDetailPage and usePartnerDetail hook
+ * to represent a company's past project participation.
+ */
+
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from './index';
+
+/** A past project record for a partner company. */
+export interface PastProject {
+  announcementId: string;
+  announcementTitle: string;
+  category: string;
+  prefecture: string;
+  branchName: string;
+  workStatus: WorkStatus;
+  evaluationStatus: EvaluationStatus;
+  priority: CompanyPriority | null;
+  bidType?: string;
+  organization: string;
+  deadline: string;
+  evaluatedAt: string;
+}


### PR DESCRIPTION
## Summary
- `judgesystem/frontend/app/src/types/` ディレクトリを作成 (#46)
- `index.ts`: EvaluationStatus, WorkStatus, CompanyPriority, DocumentOcr, Announcement 型を定義
- `announcement.ts`: AnnouncementStatus, BidType 型を定義
- `partner.ts`: PastProject 型を定義
- shared types との値整合性を確保

## 変更ファイル
- `judgesystem/frontend/app/src/types/index.ts` (新規)
- `judgesystem/frontend/app/src/types/announcement.ts` (新規)
- `judgesystem/frontend/app/src/types/partner.ts` (新規)

## Closes
Closes #46

## Test plan
- [ ] TypeScriptコンパイルが通ることを確認
- [ ] 既存のhooks/componentsからの型インポートが解決されることを確認

🤖 Generated with [Miyabi Water Spider](https://github.com/takahiro-shimizu-1/my-app)