### PR TITLE
fix(frontend): hooks エラー状態追加 + fetch タイムアウト実装

### DIFF
--- a/judgesystem/frontend/app/src/hooks/useProgressingCompanies.ts
+++ b/judgesystem/frontend/app/src/hooks/useProgressingCompanies.ts
@@ -61,16 +61,21 @@ export function useProgressingCompanies(announcementNo: string | undefined) {
 
   const [companies, setCompanies] = useState<ProgressingCompany[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Fetch from API
   useEffect(() => {
     if (!announcementNo) { setCompanies([]); return; }
     let isCancelled = false;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
     const fetchProgressingCompanies = async () => {
       setIsLoading(true);
+      setError(null);
       try {
         const response = await fetch(
           getApiUrl(`/api/announcements/${announcementNo}/progressing-companies`),
+          { signal: controller.signal },
         );
         if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
         const data = await response.json();
@@ -90,14 +95,21 @@ export function useProgressingCompanies(announcementNo: string | undefined) {
             : [],
         );
       } catch (err) {
-        console.error('Failed to fetch progressing companies:', err);
-        if (!isCancelled) setCompanies([]);
+        if (!isCancelled) {
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            setError('リクエストがタイムアウトしました');
+          } else {
+            setError(err instanceof Error ? err.message : String(err));
+          }
+          setCompanies([]);
+        }
       } finally {
+        clearTimeout(timeoutId);
         if (!isCancelled) setIsLoading(false);
       }
     };
     fetchProgressingCompanies();
-    return () => { isCancelled = true; };
+    return () => { isCancelled = true; clearTimeout(timeoutId); controller.abort(); };
   }, [announcementNo]);
 
   // Search handler
@@ -159,7 +171,7 @@ export function useProgressingCompanies(announcementNo: string | undefined) {
     sortOption, setSortOption,
     filters, setFilters,
     page, setPage, pageSize,
-    companies, isLoading,
+    companies, isLoading, error,
     filteredCompanies,
     paginatedCompanies,
     total: filteredCompanies.length,

--- a/judgesystem/frontend/app/src/hooks/useRelatedAnnouncements.ts
+++ b/judgesystem/frontend/app/src/hooks/useRelatedAnnouncements.ts
@@ -53,25 +53,41 @@ export function useRelatedAnnouncements(announcementNo: string | undefined) {
 
   // Base data fetched from API
   const [baseRelatedAnnouncements, setBaseRelatedAnnouncements] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!announcementNo) { setBaseRelatedAnnouncements([]); return; }
     let isCancelled = false;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
     const fetchRelated = async () => {
+      setIsLoading(true);
+      setError(null);
       try {
         const response = await fetch(
           getApiUrl(`/api/announcements/${announcementNo}/related`),
+          { signal: controller.signal },
         );
         if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
         const data = await response.json();
         if (!isCancelled) setBaseRelatedAnnouncements(Array.isArray(data) ? data : []);
       } catch (err) {
-        console.error('Failed to fetch related announcements:', err);
-        if (!isCancelled) setBaseRelatedAnnouncements([]);
+        if (!isCancelled) {
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            setError('リクエストがタイムアウトしました');
+          } else {
+            setError(err instanceof Error ? err.message : String(err));
+          }
+          setBaseRelatedAnnouncements([]);
+        }
+      } finally {
+        clearTimeout(timeoutId);
+        if (!isCancelled) setIsLoading(false);
       }
     };
     fetchRelated();
-    return () => { isCancelled = true; };
+    return () => { isCancelled = true; clearTimeout(timeoutId); controller.abort(); };
   }, [announcementNo]);
 
   // Search handler
@@ -148,5 +164,7 @@ export function useRelatedAnnouncements(announcementNo: string | undefined) {
     total: filteredAnnouncements.length,
     handleSearchChange,
     clear,
+    error,
+    isLoading,
   };
 }

--- a/judgesystem/frontend/app/src/pages/AnnouncementDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/AnnouncementDetailPage.tsx
@@ -1149,26 +1149,34 @@ export default function AnnouncementDetailPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!id) return;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
     const fetchAnnouncement = async () => {
-      if (!id) return;
       setLoading(true);
       setError(null);
       try {
         // id から ann- プレフィックスを除去して公告番号を取得
         const announcementNo = id.startsWith('ann-') ? id.substring(4) : id;
-        const response = await fetch(getApiUrl(`/api/announcements/${announcementNo}`));
+        const response = await fetch(getApiUrl(`/api/announcements/${announcementNo}`), { signal: controller.signal });
         if (!response.ok) {
           throw new Error(`Failed to fetch announcement: ${response.status}`);
         }
         const data = await response.json();
         setAnnouncement(data);
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          setError('リクエストがタイムアウトしました');
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
       } finally {
+        clearTimeout(timeoutId);
         setLoading(false);
       }
     };
     fetchAnnouncement();
+    return () => { clearTimeout(timeoutId); controller.abort(); };
   }, [id]);
 
   // Composed hooks


### PR DESCRIPTION
## Summary
- `useRelatedAnnouncements` / `useProgressingCompanies` に `error` state を追加 (#49)
- 全fetchに `AbortController` + 30秒タイムアウトを実装 (#50)
- `AnnouncementDetailPage` のfetchにもタイムアウトを追加
- タイムアウト時は日本語エラーメッセージ「リクエストがタイムアウトしました」を表示

## 変更ファイル
- `judgesystem/frontend/app/src/hooks/useRelatedAnnouncements.ts`
- `judgesystem/frontend/app/src/hooks/useProgressingCompanies.ts`
- `judgesystem/frontend/app/src/pages/AnnouncementDetailPage.tsx`

## Closes
Closes #49, Closes #50

## Test plan
- [ ] 正常系: APIからデータ取得が動作することを確認
- [ ] エラー系: ネットワークエラー時にerror stateが設定されることを確認
- [ ] タイムアウト: 30秒後にAbortされることを確認
- [ ] cleanup: コンポーネントアンマウント時にfetchがキャンセルされることを確認

🤖 Generated with [Miyabi Water Spider](https://github.com/takahiro-shimizu-1/my-app)