### PR TITLE
refactor: any型を具体的な型に修正 + CompanyPriority共有型追加

### DIFF
--- a/judgesystem/backend/app/src/repositories/announcementRepository.ts
+++ b/judgesystem/backend/app/src/repositories/announcementRepository.ts
@@ -1,12 +1,13 @@
 import { pool, TABLES, schemaPrefix } from "../config/database";
 import { FilterParams } from "../types";
+import type { AnnouncementListItem } from "../../../../shared/types";
 
 export class AnnouncementRepository {
   /**
    * Get paginated announcements list with filters
    * bid_announcements テーブルから一覧表示に必要な最小限のデータを取得
    */
-  async findWithFilters(filters: FilterParams): Promise<{ data: any[]; total: number }> {
+  async findWithFilters(filters: FilterParams): Promise<{ data: AnnouncementListItem[]; total: number }> {
     const { whereClause, queryParams, paramIndex } = this.buildWhereClause(filters);
 
     const page = filters.page || 0;
@@ -51,7 +52,7 @@ export class AnnouncementRepository {
    * Find single announcement by announcement_no
    * bid_announcements をベースに、documents と competing_companies を取得
    */
-  async findByNo(announcementNo: number): Promise<any | null> {
+  async findByNo(announcementNo: number): Promise<Record<string, unknown> | null> {
     const client = await pool.connect();
     try {
       const result = await client.query(
@@ -163,7 +164,7 @@ export class AnnouncementRepository {
   /**
    * Get progressing companies (raw data - Service computes statuses)
    */
-  async findProgressingCompanies(announcementNo: number): Promise<any[]> {
+  async findProgressingCompanies(announcementNo: number): Promise<Record<string, unknown>[]> {
     const client = await pool.connect();
     try {
       const result = await client.query(
@@ -208,7 +209,7 @@ export class AnnouncementRepository {
   /**
    * Get similar cases for a specific announcement (by announcement_no)
    */
-  async findSimilarCases(announcementNo: number): Promise<any[]> {
+  async findSimilarCases(announcementNo: number): Promise<Record<string, unknown>[]> {
     const client = await pool.connect();
     try {
       const announcementIdCandidates = [`ann-${announcementNo}`, String(announcementNo)];
@@ -272,7 +273,7 @@ export class AnnouncementRepository {
   /**
    * Get document metadata for a specific document (data only, no GCS)
    */
-  async findDocumentMeta(announcementNo: number, documentId: string): Promise<any | null> {
+  async findDocumentMeta(announcementNo: number, documentId: string): Promise<Record<string, unknown> | null> {
     const client = await pool.connect();
     try {
       const result = await client.query(
@@ -303,7 +304,7 @@ export class AnnouncementRepository {
   /**
    * Find related announcements by same category/organization/location.
    */
-  async findRelated(announcementNo: number): Promise<any[]> {
+  async findRelated(announcementNo: number): Promise<Record<string, unknown>[]> {
     const client = await pool.connect();
     try {
       const result = await client.query(
@@ -348,11 +349,11 @@ export class AnnouncementRepository {
    */
   private buildWhereClause(filters: FilterParams): {
     whereClause: string;
-    queryParams: any[];
+    queryParams: unknown[];
     paramIndex: number;
   } {
     const whereClauses: string[] = [];
-    const queryParams: any[] = [];
+    const queryParams: unknown[] = [];
     let paramIndex = 1;
 
     if (filters.bidTypes && filters.bidTypes.length > 0) {

--- a/judgesystem/backend/app/src/services/announcementService.ts
+++ b/judgesystem/backend/app/src/services/announcementService.ts
@@ -1,7 +1,97 @@
 import { AnnouncementRepository } from "../repositories/announcementRepository";
 import { DocumentService } from "./documentService";
-import type { FilterParams, PaginatedResponse, AnnouncementListItem, AnnouncementStatus } from "../../../../shared/types";
+import type { FilterParams, PaginatedResponse, AnnouncementListItem, AnnouncementStatus, Department, DocumentMeta } from "../../../../shared/types";
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from "../../../../shared/constants";
+
+// -- Service-layer response types --
+
+/** Full announcement detail returned by getByNo. */
+export interface AnnouncementDetail {
+  id: string;
+  no: number;
+  announcementNo: number;
+  ordererId: string;
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  department: Department;
+  publishDate: string;
+  explanationStartDate: string;
+  explanationEndDate: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  bidStartDate: string;
+  bidEndDate: string;
+  deadline: string;
+  estimatedAmountMin: number | null;
+  estimatedAmountMax: number | null;
+  actualAmount: number | null;
+  winningCompanyId: string | null;
+  winningCompanyName: string | null;
+  documents: DocumentMeta[];
+  competingCompanies: CompetingCompany[];
+}
+
+/** Competing company entry within an announcement detail. */
+interface CompetingCompany {
+  name: string;
+  isWinner: boolean;
+  bidAmounts: number[];
+}
+
+/** Row returned by the progressing-companies query. */
+export interface ProgressingCompanyRow {
+  evaluationId: string;
+  announcementNo: string;
+  companyId: string;
+  companyName: string;
+  branchId: string;
+  branchName: string;
+  branchAddress: string;
+  companyAddress: string;
+  finalStatus: boolean;
+  requirementIneligibility: boolean;
+  requirementGradeItem: boolean;
+  requirementLocation: boolean;
+  requirementExperience: boolean;
+  requirementTechnician: boolean;
+  requirementOther: boolean;
+  workStatus: string | null;
+  updatedAt: string | null;
+}
+
+/** Similar case entry returned by getSimilarCases. */
+export interface SimilarCaseRow {
+  id: string;
+  announcementId: string;
+  similarAnnouncementId: string;
+  caseName: string;
+  winningCompany: string;
+  winningAmount: number | null;
+  competitors: string[];
+}
+
+/** Related announcement returned by getRelated. */
+export interface RelatedAnnouncementRow {
+  id: string;
+  no: number;
+  announcementNo: number;
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  publishDate: string;
+  deadline: string;
+}
+
+/** Announcement with a status field (used by filter/sort helpers). */
+interface AnnouncementWithStatus {
+  status: AnnouncementStatus;
+  [key: string]: unknown;
+}
 
 /**
  * Determine announcement status from the bid end date.
@@ -117,9 +207,11 @@ export class AnnouncementService {
    * Get a single announcement by announcement_no.
    * Flow: repository (raw data with documents) -> enrich documents via GCS -> return
    */
-  async getByNo(announcementNo: number): Promise<any | null> {
-    const announcement = await this.repository.findByNo(announcementNo);
-    if (!announcement) return null;
+  async getByNo(announcementNo: number): Promise<AnnouncementDetail | null> {
+    const row = await this.repository.findByNo(announcementNo);
+    if (!row) return null;
+
+    const announcement = row as unknown as AnnouncementDetail;
 
     // Enrich documents with GCS markdown content
     if (announcement.documents && Array.isArray(announcement.documents)) {
@@ -136,15 +228,17 @@ export class AnnouncementService {
    * Get companies progressing on a given announcement
    * (those with workStatus in_progress or completed).
    */
-  async getProgressingCompanies(announcementNo: number): Promise<any[]> {
-    return this.repository.findProgressingCompanies(announcementNo);
+  async getProgressingCompanies(announcementNo: number): Promise<ProgressingCompanyRow[]> {
+    const rows = await this.repository.findProgressingCompanies(announcementNo);
+    return rows as unknown as ProgressingCompanyRow[];
   }
 
   /**
    * Get similar cases for an announcement.
    */
-  async getSimilarCases(announcementNo: number): Promise<any[]> {
-    return this.repository.findSimilarCases(announcementNo);
+  async getSimilarCases(announcementNo: number): Promise<SimilarCaseRow[]> {
+    const rows = await this.repository.findSimilarCases(announcementNo);
+    return rows as unknown as SimilarCaseRow[];
   }
 
   /**
@@ -155,35 +249,36 @@ export class AnnouncementService {
     announcementNo: number,
     documentId: string
   ): Promise<{ data: Buffer; fileFormat: string; title: string } | null> {
-    const meta = await this.repository.findDocumentMeta(announcementNo, documentId);
-    if (!meta) return null;
+    const row = await this.repository.findDocumentMeta(announcementNo, documentId);
+    if (!row) return null;
 
-    const gcsPath = meta.save_path;
+    const gcsPath = row.save_path as string | undefined;
     if (!gcsPath || !gcsPath.startsWith("gs://")) return null;
 
     const data = await this.documentService.downloadDocument(gcsPath);
     return {
       data,
-      fileFormat: meta.fileFormat || "pdf",
-      title: meta.title || `document-${documentId}`,
+      fileFormat: (row.fileFormat as string) || "pdf",
+      title: (row.title as string) || `document-${documentId}`,
     };
   }
 
   /**
    * Get related announcements sharing category/organization/location.
    */
-  async getRelated(announcementNo: number): Promise<any[]> {
-    return this.repository.findRelated(announcementNo);
+  async getRelated(announcementNo: number): Promise<RelatedAnnouncementRow[]> {
+    const rows = await this.repository.findRelated(announcementNo);
+    return rows as unknown as RelatedAnnouncementRow[];
   }
 
   /**
    * Filter announcements by status in TypeScript.
    * Can be used when status filtering needs to happen after data retrieval.
    */
-  filterByStatuses(
-    announcements: any[],
+  filterByStatuses<T extends AnnouncementWithStatus>(
+    announcements: T[],
     statuses: AnnouncementStatus[]
-  ): any[] {
+  ): T[] {
     if (!statuses || statuses.length === 0) return announcements;
     const statusSet = new Set(statuses);
     return announcements.filter((a) => statusSet.has(a.status));
@@ -193,10 +288,10 @@ export class AnnouncementService {
    * Sort announcements by status in TypeScript.
    * Can be used for post-retrieval sorting.
    */
-  sortByStatus(
-    announcements: any[],
+  sortByStatus<T extends AnnouncementWithStatus>(
+    announcements: T[],
     direction: "asc" | "desc" = "asc"
-  ): any[] {
+  ): T[] {
     return [...announcements].sort((a, b) =>
       compareByStatus(a, b, direction)
     );

--- a/judgesystem/frontend/app/src/components/partner/PartnerBasicInfo.tsx
+++ b/judgesystem/frontend/app/src/components/partner/PartnerBasicInfo.tsx
@@ -12,6 +12,7 @@ import {
   ExpandMore as ExpandMoreIcon,
 } from '@mui/icons-material';
 import { colors, fontSizes, chipStyles, iconStyles, borderRadius } from '../../constants/styles';
+import type { PartnerDetail, PartnerBranch } from '../../types/partner';
 
 function InfoRow({ label, value, icon }: { label: string; value: React.ReactNode; icon?: React.ReactNode }) {
   return (
@@ -24,7 +25,7 @@ function InfoRow({ label, value, icon }: { label: string; value: React.ReactNode
 }
 
 interface PartnerBasicInfoProps {
-  partner: any;
+  partner: PartnerDetail;
 }
 
 export function PartnerBasicInfo({ partner }: PartnerBasicInfoProps) {
@@ -61,7 +62,7 @@ export function PartnerBasicInfo({ partner }: PartnerBasicInfoProps) {
           <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>拠点一覧 ({partner.branches.length})</Typography>
         </AccordionSummary>
         <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
-          {partner.branches.map((branch: any, index: number) => (
+          {partner.branches.map((branch: PartnerBranch, index: number) => (
             <Box key={index} sx={{ py: 1.25, borderBottom: index < partner.branches.length - 1 ? `1px solid ${colors.border.light}` : 'none' }}>
               <Typography sx={{ fontWeight: 600, fontSize: fontSizes.md, color: colors.text.secondary }}>{branch.name}</Typography>
               <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>{branch.address}</Typography>

--- a/judgesystem/frontend/app/src/components/partner/PartnerQualifications.tsx
+++ b/judgesystem/frontend/app/src/components/partner/PartnerQualifications.tsx
@@ -1,9 +1,10 @@
 import { Box, Typography, Rating, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
 import { colors, fontSizes, borderRadius } from '../../constants/styles';
+import type { PartnerDetail, UnifiedQualification, OrdererQualification, OrdererQualificationItem } from '../../types/partner';
 
 interface PartnerQualificationsProps {
-  partner: any;
+  partner: PartnerDetail;
 }
 
 export function PartnerQualifications({ partner }: PartnerQualificationsProps) {
@@ -59,7 +60,7 @@ export function PartnerQualifications({ partner }: PartnerQualificationsProps) {
                 <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'center' }}>等級</Typography>
               </Box>
               {/* テーブルボディ */}
-              {partner.qualifications.unified.map((q: any, idx: number) => (
+              {partner.qualifications.unified.map((q: UnifiedQualification, idx: number) => (
                 <Box key={idx} sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 100px 80px 70px', borderBottom: idx < partner.qualifications.unified.length - 1 ? `1px solid ${colors.border.light}` : 'none', '&:hover': { backgroundColor: 'rgba(0,0,0,0.02)' } }}>
                   <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{q.mainCategory}</Typography>
                   <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{q.category}</Typography>
@@ -77,7 +78,7 @@ export function PartnerQualifications({ partner }: PartnerQualificationsProps) {
             <Typography sx={{ color: colors.text.light, fontSize: fontSizes.sm }}>登録なし</Typography>
           ) : (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-              {partner.qualifications.orderers.map((orderer: any, idx: number) => (
+              {partner.qualifications.orderers.map((orderer: OrdererQualification, idx: number) => (
                 <Box key={idx}>
                   <Typography sx={{ fontSize: fontSizes.sm, fontWeight: 600, color: colors.text.secondary, mb: 1, pl: 1.5, borderLeft: `3px solid ${colors.accent.blue}` }}>{orderer.ordererName}</Typography>
                   <Box sx={{ border: `1px solid ${colors.border.main}`, borderRadius: borderRadius.xs, overflow: 'hidden' }}>
@@ -89,7 +90,7 @@ export function PartnerQualifications({ partner }: PartnerQualificationsProps) {
                       <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.xs, fontWeight: 600, color: colors.text.muted, textAlign: 'center' }}>等級</Typography>
                     </Box>
                     {/* テーブルボディ */}
-                    {orderer.items.map((item: any, itemIdx: number) => (
+                    {orderer.items.map((item: OrdererQualificationItem, itemIdx: number) => (
                       <Box key={itemIdx} sx={{ display: 'grid', gridTemplateColumns: '1fr 120px 80px 70px', borderBottom: itemIdx < orderer.items.length - 1 ? `1px solid ${colors.border.light}` : 'none', '&:hover': { backgroundColor: 'rgba(0,0,0,0.02)' } }}>
                         <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.secondary }}>{item.category}</Typography>
                         <Typography sx={{ px: 1.5, py: 1, fontSize: fontSizes.sm, color: colors.text.muted }}>{item.region}</Typography>

--- a/judgesystem/frontend/app/src/hooks/useProgressingCompanies.ts
+++ b/judgesystem/frontend/app/src/hooks/useProgressingCompanies.ts
@@ -17,6 +17,18 @@ export interface CompanyFilterState {
   priorities: (1 | 2 | 3 | 4 | 5)[];
 }
 
+/** Raw row shape from the progressing-companies API response. */
+interface ProgressingCompanyApiRow {
+  companyId?: string | number;
+  companyName?: string;
+  branchId?: string | number;
+  branchName?: string;
+  priority?: number;
+  workStatus?: string;
+  evaluationId?: string | number;
+  evaluationStatus?: string;
+}
+
 // -- Constants --
 
 const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
@@ -82,7 +94,7 @@ export function useProgressingCompanies(announcementNo: string | undefined) {
         if (isCancelled) return;
         setCompanies(
           Array.isArray(data)
-            ? data.map((row: any) => ({
+            ? data.map((row: ProgressingCompanyApiRow) => ({
                 companyId: String(row.companyId ?? ''),
                 companyName: row.companyName ?? '',
                 branchId: String(row.branchId ?? ''),

--- a/judgesystem/frontend/app/src/hooks/useRelatedAnnouncements.ts
+++ b/judgesystem/frontend/app/src/hooks/useRelatedAnnouncements.ts
@@ -4,6 +4,23 @@ import { getOrganizationGroup } from '../constants/organizations';
 import { getApiUrl } from '../config/api';
 import type { AnnouncementStatus } from '../types/announcement';
 
+// -- Related announcement row returned by the API --
+
+/** A related announcement entry from the backend. */
+export interface RelatedAnnouncement {
+  id: string;
+  no: number;
+  announcementNo: number;
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  publishDate: string;
+  deadline: string;
+  status?: string;
+}
+
 // -- Types --
 
 export type SortOption =
@@ -52,7 +69,7 @@ export function useRelatedAnnouncements(announcementNo: string | undefined) {
   const pageSize = 25;
 
   // Base data fetched from API
-  const [baseRelatedAnnouncements, setBaseRelatedAnnouncements] = useState<any[]>([]);
+  const [baseRelatedAnnouncements, setBaseRelatedAnnouncements] = useState<RelatedAnnouncement[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
@@ -31,7 +31,7 @@ import { NotFoundView, FloatingBackButton, ScrollToTopButton, FilterButton } fro
 import { RightSidePanel } from '../components/layout';
 import { PartnerBasicInfo, PartnerQualifications, PartnerHistory } from '../components/partner';
 import { useSidebar } from '../contexts/SidebarContext';
-import type { PastProject } from '../types/partner';
+import type { PastProject, PartnerDetail } from '../types/partner';
 import type { BidType } from '../types/announcement';
 import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../types';
 import { getApiUrl } from '../config/api';
@@ -815,7 +815,7 @@ export default function PartnerDetailPage() {
   const [conditionTab, setConditionTab] = useState<'sort' | 'filter'>('sort');
 
   // APIからデータ取得
-  const [partner, setPartner] = useState<any>(null);
+  const [partner, setPartner] = useState<PartnerDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/judgesystem/frontend/app/src/types/partner.ts
+++ b/judgesystem/frontend/app/src/types/partner.ts
@@ -22,3 +22,62 @@ export interface PastProject {
   deadline: string;
   evaluatedAt: string;
 }
+
+/** Branch (office) within a partner company. */
+export interface PartnerBranch {
+  name: string;
+  address: string;
+}
+
+/** Unified qualification row. */
+export interface UnifiedQualification {
+  mainCategory: string;
+  category: string;
+  region: string;
+  value: number;
+  grade: string;
+}
+
+/** Item within an orderer-specific qualification. */
+export interface OrdererQualificationItem {
+  category: string;
+  region: string;
+  value: number;
+  grade: string;
+}
+
+/** Orderer-specific qualification group. */
+export interface OrdererQualification {
+  ordererName: string;
+  items: OrdererQualificationItem[];
+}
+
+/** Partner qualifications data. */
+export interface PartnerQualifications {
+  unified: UnifiedQualification[];
+  orderers: OrdererQualification[];
+}
+
+/** Full partner detail returned by the API. */
+export interface PartnerDetail {
+  id: string;
+  no: number;
+  name: string;
+  address: string;
+  postalCode: string;
+  phone: string;
+  fax: string;
+  email: string;
+  url?: string;
+  representative: string;
+  established: number;
+  capital: number | null;
+  employeeCount: number | null;
+  rating: number | null;
+  surveyCount: number | null;
+  resultCount: number | null;
+  branches: PartnerBranch[];
+  categories: string[];
+  pastProjects: PastProject[];
+  qualifications: PartnerQualifications;
+}

--- a/judgesystem/shared/types/evaluation.ts
+++ b/judgesystem/shared/types/evaluation.ts
@@ -28,6 +28,9 @@ export const VALID_CURRENT_STEPS: ReadonlySet<string> = new Set([
   "final_review",
 ]);
 
+/** Company priority ranking (1 = highest, 5 = lowest). */
+export type CompanyPriority = 1 | 2 | 3 | 4 | 5;
+
 // -- Concrete response types --
 
 export interface EvaluationListItem {

--- a/judgesystem/shared/types/index.ts
+++ b/judgesystem/shared/types/index.ts
@@ -2,6 +2,7 @@ export type {
   EvaluationStatus,
   WorkStatus,
   CurrentStep,
+  CompanyPriority,
   EvaluationListItem,
   StatusCounts,
   AssigneeRecord,


### PR DESCRIPTION
## Summary
- `CompanyPriority` 型を shared types に追加 (#48)
- backend/frontend全体の `any` 型を具体的な型に置換 (#47)
- 新規インターフェース: AnnouncementDetail, ProgressingCompanyRow, RelatedAnnouncement, PartnerDetail等

## Closes
Closes #47, Closes #48

## Test plan
- [ ] TypeScriptコンパイルが通ることを確認

🤖 Generated with Miyabi Water Spider