### PR TITLE
fix(backend): DB Poolエラーハンドラ+タイムアウト設定

### DIFF
--- a/judgesystem/backend/app/src/config/database.ts
+++ b/judgesystem/backend/app/src/config/database.ts
@@ -19,10 +19,17 @@ const buildPoolConfig = (): PoolConfig => {
     };
   }
 
+  config.connectionTimeoutMillis = 10000; // 10 seconds
+  config.idleTimeoutMillis = 30000; // 30 seconds
+
   return config;
 };
 
 export const pool = new Pool(buildPoolConfig());
+
+pool.on("error", (err) => {
+  console.error("Unexpected PostgreSQL pool error:", err);
+});
 
 export const TABLES = {
   orderers: "bid_orderers",


### PR DESCRIPTION
## Summary
- `pool.on('error')` ハンドラ追加でサイレント失敗を防止 (#52)
- `connectionTimeoutMillis: 10000` / `idleTimeoutMillis: 30000` 設定

## Closes
Closes #52

## Test plan
- [ ] DB接続が正常に動作することを確認

🤖 Generated with Miyabi Water Spider