### PR TITLE
refactor(backend): エラーレスポンス形式統一+ルートバリデーション整理

### DIFF
--- a/judgesystem/backend/app/src/routes/announcementRoutes.ts
+++ b/judgesystem/backend/app/src/routes/announcementRoutes.ts
@@ -12,7 +12,7 @@ router.get("/", async (req: Request, res: Response) => {
     res.json(result);
   } catch (err) {
     console.error("GET /api/announcements error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -20,18 +20,18 @@ router.get("/:announcementNo", async (req: Request, res: Response) => {
   try {
     const no = Number(req.params.announcementNo);
     if (isNaN(no)) {
-      res.status(400).json({ error: "Invalid announcement number" });
+      res.status(400).json({ error: "Invalid announcement number", code: "VALIDATION_ERROR" });
       return;
     }
     const announcement = await service.getByNo(no);
     if (!announcement) {
-      res.status(404).json({ error: "Announcement not found" });
+      res.status(404).json({ error: "Announcement not found", code: "NOT_FOUND" });
       return;
     }
     res.json(announcement);
   } catch (err) {
     console.error("GET /api/announcements/:announcementNo error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -39,14 +39,14 @@ router.get("/:announcementNo/progressing-companies", async (req: Request, res: R
   try {
     const no = Number(req.params.announcementNo);
     if (isNaN(no)) {
-      res.status(400).json({ error: "Invalid announcement number" });
+      res.status(400).json({ error: "Invalid announcement number", code: "VALIDATION_ERROR" });
       return;
     }
     const companies = await service.getProgressingCompanies(no);
     res.json(companies);
   } catch (err) {
     console.error("GET /api/announcements/:announcementNo/progressing-companies error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -54,14 +54,14 @@ router.get("/:announcementNo/similar-cases", async (req: Request, res: Response)
   try {
     const no = Number(req.params.announcementNo);
     if (isNaN(no)) {
-      res.status(400).json({ error: "Invalid announcement number" });
+      res.status(400).json({ error: "Invalid announcement number", code: "VALIDATION_ERROR" });
       return;
     }
     const cases = await service.getSimilarCases(no);
     res.json(cases);
   } catch (err) {
     console.error("GET /api/announcements/:announcementNo/similar-cases error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -69,14 +69,14 @@ router.get("/:announcementNo/related", async (req: Request, res: Response) => {
   try {
     const no = Number(req.params.announcementNo);
     if (isNaN(no)) {
-      res.status(400).json({ error: "Invalid announcement number" });
+      res.status(400).json({ error: "Invalid announcement number", code: "VALIDATION_ERROR" });
       return;
     }
     const related = await service.getRelated(no);
     res.json(related);
   } catch (err) {
     console.error("GET /api/announcements/:announcementNo/related error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -84,12 +84,12 @@ router.get("/:announcementNo/documents/:documentId/preview", async (req: Request
   try {
     const no = Number(req.params.announcementNo);
     if (isNaN(no)) {
-      res.status(400).json({ error: "Invalid announcement number" });
+      res.status(400).json({ error: "Invalid announcement number", code: "VALIDATION_ERROR" });
       return;
     }
     const result = await service.getDocumentPreview(no, req.params.documentId);
     if (!result) {
-      res.status(404).json({ error: "Document not found" });
+      res.status(404).json({ error: "Document not found", code: "NOT_FOUND" });
       return;
     }
     res.setHeader("Content-Type", `application/${result.fileFormat || "pdf"}`);
@@ -97,7 +97,7 @@ router.get("/:announcementNo/documents/:documentId/preview", async (req: Request
     res.send(result.data);
   } catch (err) {
     console.error("GET /api/announcements/:announcementNo/documents/:documentId/preview error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 

--- a/judgesystem/backend/app/src/routes/evaluationRoutes.ts
+++ b/judgesystem/backend/app/src/routes/evaluationRoutes.ts
@@ -11,7 +11,7 @@ router.get("/stats", async (req: Request, res: Response) => {
     res.json(stats);
   } catch (err) {
     console.error("GET /api/evaluations/stats error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -22,7 +22,7 @@ router.get("/status-counts", async (req: Request, res: Response) => {
     res.json(counts);
   } catch (err) {
     console.error("GET /api/evaluations/status-counts error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -33,7 +33,7 @@ router.get("/", async (req: Request, res: Response) => {
     res.json(result);
   } catch (err) {
     console.error("GET /api/evaluations error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -41,13 +41,13 @@ router.get("/:id", async (req: Request, res: Response) => {
   try {
     const evaluation = await service.getById(req.params.id);
     if (!evaluation) {
-      res.status(404).json({ error: "Evaluation not found" });
+      res.status(404).json({ error: "Evaluation not found", code: "NOT_FOUND" });
       return;
     }
     res.json(evaluation);
   } catch (err) {
     console.error("GET /api/evaluations/:id error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -55,7 +55,7 @@ router.patch("/:evaluationNo", async (req: Request, res: Response) => {
   try {
     const { workStatus, currentStep } = req.body;
     if (!workStatus) {
-      res.status(400).json({ error: "workStatus is required" });
+      res.status(400).json({ error: "workStatus is required", code: "VALIDATION_ERROR" });
       return;
     }
     const result = await service.updateWorkStatus(
@@ -64,17 +64,17 @@ router.patch("/:evaluationNo", async (req: Request, res: Response) => {
       currentStep
     );
     if (!result) {
-      res.status(404).json({ error: "Evaluation not found" });
+      res.status(404).json({ error: "Evaluation not found", code: "NOT_FOUND" });
       return;
     }
     res.json(result);
   } catch (err: any) {
     if (err.message?.startsWith("Invalid")) {
-      res.status(400).json({ error: err.message });
+      res.status(400).json({ error: err.message, code: "VALIDATION_ERROR" });
       return;
     }
     console.error("PATCH /api/evaluations/:evaluationNo error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -84,7 +84,7 @@ router.get("/:evaluationNo/assignees", async (req: Request, res: Response) => {
     res.json(assignees);
   } catch (err) {
     console.error("GET /api/evaluations/:evaluationNo/assignees error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
@@ -95,13 +95,13 @@ router.put("/:evaluationNo/assignees", async (req: Request, res: Response) => {
       req.body
     );
     if (!result) {
-      res.status(404).json({ error: "Evaluation not found" });
+      res.status(404).json({ error: "Evaluation not found", code: "NOT_FOUND" });
       return;
     }
     res.json(result);
   } catch (err) {
     console.error("PUT /api/evaluations/:evaluationNo/assignees error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 

--- a/judgesystem/backend/app/src/routes/ordererRoutes.ts
+++ b/judgesystem/backend/app/src/routes/ordererRoutes.ts
@@ -1,32 +1,32 @@
 import { Router, Request, Response } from "express";
 import { OrdererService } from "../services/ordererService";
+import { parsePagination } from "../utils/validation";
 
 const router = Router();
 const service = new OrdererService();
 
 router.get("/", async (req: Request, res: Response) => {
   try {
-    const page = Number(req.query.page ?? 0);
-    const pageSize = Number(req.query.pageSize ?? 25);
-    const result = await service.getList(
-      isNaN(page) || page < 0 ? 0 : page,
-      isNaN(pageSize) || pageSize < 1 ? 25 : pageSize
-    );
+    const { page, pageSize } = parsePagination(req.query as Record<string, any>);
+    const result = await service.getList(page, pageSize);
     res.json(result);
   } catch (err) {
     console.error("GET /api/orderers error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
 router.get("/:id", async (req: Request, res: Response) => {
   try {
     const orderer = await service.getById(req.params.id);
-    if (!orderer) { res.status(404).json({ error: "Orderer not found" }); return; }
+    if (!orderer) {
+      res.status(404).json({ error: "Orderer not found", code: "NOT_FOUND" });
+      return;
+    }
     res.json(orderer);
   } catch (err) {
     console.error("GET /api/orderers/:id error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 

--- a/judgesystem/backend/app/src/routes/partnerRoutes.ts
+++ b/judgesystem/backend/app/src/routes/partnerRoutes.ts
@@ -1,32 +1,32 @@
 import { Router, Request, Response } from "express";
 import { PartnerService } from "../services/partnerService";
+import { parsePagination } from "../utils/validation";
 
 const router = Router();
 const service = new PartnerService();
 
 router.get("/", async (req: Request, res: Response) => {
   try {
-    const page = Number(req.query.page ?? 0);
-    const pageSize = Number(req.query.pageSize ?? 25);
-    const result = await service.getList(
-      isNaN(page) || page < 0 ? 0 : page,
-      isNaN(pageSize) || pageSize < 1 ? 25 : pageSize
-    );
+    const { page, pageSize } = parsePagination(req.query as Record<string, any>);
+    const result = await service.getList(page, pageSize);
     res.json(result);
   } catch (err) {
     console.error("GET /api/partners error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 
 router.get("/:id", async (req: Request, res: Response) => {
   try {
     const partner = await service.getById(req.params.id);
-    if (!partner) { res.status(404).json({ error: "Partner not found" }); return; }
+    if (!partner) {
+      res.status(404).json({ error: "Partner not found", code: "NOT_FOUND" });
+      return;
+    }
     res.json(partner);
   } catch (err) {
     console.error("GET /api/partners/:id error:", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ error: "Internal server error", code: "INTERNAL_ERROR" });
   }
 });
 


### PR DESCRIPTION
## Summary
- 全エラーレスポンスに `code` フィールド追加 (#53)
- パジネーション解析を `parsePagination()` に統一 (#51)

## Closes
Closes #51, Closes #53

🤖 Generated with Miyabi Water Spider