### PR TITLE
fix(backend): ビルド設定追加 + ESM __dirname修正

### DIFF
--- a/judgesystem/backend/app/package.json
+++ b/judgesystem/backend/app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "judgesystem-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch index.ts",
+    "start": "tsx index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "cors": "^2.8.5",
+    "compression": "^1.7.4",
+    "pg": "^8.13.0",
+    "@google-cloud/storage": "^7.14.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/cors": "^2.8.17",
+    "@types/compression": "^1.7.5",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/judgesystem/backend/app/src/config/migrations.ts
+++ b/judgesystem/backend/app/src/config/migrations.ts
@@ -1,7 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { pool, schemaPrefix } from "./database";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const MIGRATIONS_DIR = path.join(__dirname, "..", "migrations");
 
 async function ensureMigrationsTable(): Promise<void> {

--- a/judgesystem/backend/app/tsconfig.json
+++ b/judgesystem/backend/app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- **package.json**: バックエンドアプリ用の新規 `package.json` を追加。`"type": "module"` でESM対応、依存関係（express, pg, cors等）とdevDependencies（tsx, typescript, vitest等）を定義
- **tsconfig.json**: TypeScript strict mode + ESNext module + bundler moduleResolution の設定ファイルを追加
- **migrations.ts**: CJS の `__dirname` を ESM互換の `fileURLToPath(import.meta.url)` パターンに修正

Closes #71

## Test plan

- [ ] `cd judgesystem/backend/app && npx tsc --noEmit` でTypeScriptコンパイルエラーがないことを確認
- [ ] `npm install` で依存関係が正常にインストールされることを確認
- [ ] マイグレーション実行時に `__dirname` エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)