### PR TITLE
feat(frontend): ビルド設定ファイル追加 (#69)

### DIFF
--- a/judgesystem/frontend/app/eslint.config.js
+++ b/judgesystem/frontend/app/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactHooks.configs.flat.recommended,
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/judgesystem/frontend/app/index.html
+++ b/judgesystem/frontend/app/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>bidsystem_ui</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/judgesystem/frontend/app/package.json
+++ b/judgesystem/frontend/app/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "bidsystem_ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.5",
+    "@mui/material": "^7.3.5",
+    "@mui/x-data-grid": "^8.20.0",
+    "@tanstack/react-virtual": "^3.13.12",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.9.6"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.5",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "globals": "^16.5.0",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.46.4",
+    "vite": "^7.2.4"
+  }
+}

--- a/judgesystem/frontend/app/src/index.css
+++ b/judgesystem/frontend/app/src/index.css
@@ -1,0 +1,14 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/judgesystem/frontend/app/tsconfig.app.json
+++ b/judgesystem/frontend/app/tsconfig.app.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/judgesystem/frontend/app/tsconfig.json
+++ b/judgesystem/frontend/app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/judgesystem/frontend/app/tsconfig.node.json
+++ b/judgesystem/frontend/app/tsconfig.node.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/judgesystem/frontend/app/vite.config.ts
+++ b/judgesystem/frontend/app/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- オリジナルfrontend (`judgesystem/source/bid_apps/postgres/frontend/app/`) からビルド設定ファイルをリファクタリング先 (`judgesystem/frontend/app/`) にコピー
- `vite.config.ts` にバックエンドAPI proxy設定 (`/api` -> `localhost:8080`) を追加
- 全依存関係・TypeScript設定・ESLint設定はオリジナルのまま維持

## Files Added

| File | Description |
|------|-------------|
| `package.json` | 依存関係定義（React 19, MUI 7, Vite 7, TypeScript 5.9） |
| `vite.config.ts` | Viteビルド設定 + API proxy |
| `tsconfig.json` | TypeScript設定ルート（references） |
| `tsconfig.app.json` | アプリ用TS設定（strict mode, ES2022） |
| `tsconfig.node.json` | Node用TS設定（ES2023） |
| `index.html` | HTMLエントリーポイント |
| `src/index.css` | グローバルCSS（リセット + 基本スタイル） |
| `eslint.config.js` | ESLint flat config |

## Changes from Original

- `vite.config.ts`: `server.proxy` 設定を追加（`/api` -> `http://localhost:8080`）
- その他のファイル: 変更なし（オリジナルのまま）

## Test plan

- [ ] `cd judgesystem/frontend/app && npm install` が成功すること
- [ ] `npm run build` がTypeScriptエラーなくビルド成功すること
- [ ] `npm run dev` でdev serverが起動し、`/api` リクエストがバックエンドにproxy転送されること
- [ ] `npm run lint` がESLintエラー0件であること

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)