### PR TITLE
refactor(frontend): any 型除去 + 型安全性向上

### DIFF
--- a/judgesystem/frontend/app/src/hooks/useAnnouncementListState.ts
+++ b/judgesystem/frontend/app/src/hooks/useAnnouncementListState.ts
@@ -4,6 +4,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { GridFilterModel, GridSortModel, GridPaginationModel } from '@mui/x-data-grid';
 import type { AnnouncementFilterState } from '../components/announcement';
+import type { AnnouncementListRow } from '../types';
 import { getApiUrl } from '../config/api';
 
 // ローカルストレージのキー
@@ -60,7 +61,7 @@ async function fetchAnnouncements(params: {
   filters: AnnouncementFilterState;
   searchQuery: string;
   sortModel: GridSortModel;
-}): Promise<{ data: any[]; total: number }> {
+}): Promise<{ data: AnnouncementListRow[]; total: number }> {
   const { page, pageSize, filters, searchQuery, sortModel } = params;
 
   // クエリパラメータを構築
@@ -140,7 +141,7 @@ export function useAnnouncementListState() {
   );
 
   // データ取得状態
-  const [rows, setRows] = useState<any[]>([]);
+  const [rows, setRows] = useState<AnnouncementListRow[]>([]);
   const [rowCount, setRowCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/judgesystem/frontend/app/src/hooks/useBidListState.ts
+++ b/judgesystem/frontend/app/src/hooks/useBidListState.ts
@@ -5,7 +5,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { GridFilterModel, GridSortModel, GridPaginationModel } from '@mui/x-data-grid';
 import { extractPrefecture } from '../constants/prefectures';
-import type { EvaluationStatus, FilterState } from '../types';
+import type { EvaluationStatus, FilterState, EvaluationApiItem, EvaluationListRow } from '../types';
 import { getApiUrl } from '../config/api';
 
 // ナビゲーション追跡用のsessionStorageキー
@@ -115,7 +115,7 @@ async function fetchEvaluations(params: {
   filters: FilterState;
   searchQuery: string;
   sortModel: GridSortModel;
-}): Promise<{ data: any[]; total: number }> {
+}): Promise<{ data: EvaluationApiItem[]; total: number }> {
   const { page, pageSize, filters, searchQuery, sortModel } = params;
 
   // クエリパラメータを構築
@@ -215,7 +215,7 @@ export function useBidListState() {
   const [showFilterModal, setShowFilterModal] = useState(false);
 
   // API状態
-  const [rows, setRows] = useState<any[]>([]);
+  const [rows, setRows] = useState<EvaluationListRow[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -298,7 +298,7 @@ export function useBidListState() {
             throw new Error('Invalid API response: data is not an array');
           }
 
-          const mapped = result.data.map((e: any) => ({
+          const mapped = result.data.map((e: EvaluationApiItem): EvaluationListRow => ({
             id: e.id,
             evaluationNo: e.evaluationNo,
             status: e.status,

--- a/judgesystem/frontend/app/src/hooks/usePartnerDetail.ts
+++ b/judgesystem/frontend/app/src/hooks/usePartnerDetail.ts
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { getApiUrl } from '../config/api';
-import type { PastProject } from '../types/partner';
+import type { PastProject, PartnerDetail } from '../types/partner';
 import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../types';
 
 // -- Types --
@@ -27,7 +27,7 @@ export interface ProjectFilterState {
 // -- Constants --
 
 const WORK_STATUS_ORDER: Record<WorkStatus, number> = {
-  not_started: 0, in_progress: 1, completed: 2,
+  not_started: 0, in_progress: 1, completed: 2, on_hold: 3, cancelled: 4,
 };
 const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
   all_met: 0, other_only_unmet: 1, unmet: 2,
@@ -47,7 +47,7 @@ export function usePartnerDetail() {
   const location = useLocation();
 
   const [activeTab, setActiveTab] = useState(0);
-  const [partner, setPartner] = useState<any>(null);
+  const [partner, setPartner] = useState<PartnerDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -72,7 +72,7 @@ export function usePartnerDetail() {
       try {
         const response = await fetch(getApiUrl(`/api/partners/${id}`));
         if (!response.ok) throw new Error(`Failed to fetch partner: ${response.status}`);
-        setPartner(await response.json());
+        setPartner(await response.json() as PartnerDetail);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       } finally {

--- a/judgesystem/frontend/app/src/types/index.ts
+++ b/judgesystem/frontend/app/src/types/index.ts
@@ -18,6 +18,18 @@ export type CurrentStep = 'judgment' | 'document_review' | 'field_survey' | 'fin
 /** Company priority ranking (1 = highest, 5 = lowest). */
 export type CompanyPriority = 1 | 2 | 3 | 4 | 5;
 
+/** Lifecycle status of an announcement. */
+export type AnnouncementStatus = 'upcoming' | 'ongoing' | 'awaiting_result' | 'closed';
+
+/** Bid type classification. */
+export type BidType =
+  | 'general-competitive-bidding'
+  | 'design-competition'
+  | 'one-off'
+  | 'proposal'
+  | 'negotiated-contract'
+  | 'unknown';
+
 /** OCR-extracted document metadata attached to an announcement. */
 export interface DocumentOcr {
   id: number;
@@ -43,4 +55,78 @@ export interface Announcement {
   estimatedAmountMin: number | null;
   estimatedAmountMax: number | null;
   documents?: DocumentOcr[];
+}
+
+// ---------------------------------------------------------------------------
+// Filter state
+// ---------------------------------------------------------------------------
+
+/** Filter state for the bid (evaluation) list page. */
+export interface FilterState {
+  statuses: string[];
+  workStatuses: string[];
+  priorities: string[];
+  categories: string[];
+  bidTypes: string[];
+  organizations: string[];
+  prefectures: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Row types used by list hooks / DataGrid
+// ---------------------------------------------------------------------------
+
+/** Row type for the announcement list DataGrid (matches API response shape). */
+export interface AnnouncementListRow {
+  id: string;
+  announcementNo: number;
+  title: string;
+  organization: string;
+  category: string;
+  bidType: string;
+  workLocation: string;
+  publishDate: string;
+  deadline: string;
+}
+
+/** Raw evaluation item returned from the /api/evaluations endpoint. */
+export interface EvaluationApiItem {
+  id: string;
+  evaluationNo: string;
+  status: EvaluationStatus;
+  workStatus: WorkStatus | null;
+  announcement: {
+    title: string;
+    organization: string;
+    category: string;
+    bidType: string;
+    deadline: string;
+    workLocation: string;
+  } | null;
+  company: {
+    name: string;
+    priority: CompanyPriority | null;
+  } | null;
+  branch: {
+    name: string;
+  } | null;
+  evaluatedAt: string | null;
+}
+
+/** Flattened row type for the evaluation list DataGrid. */
+export interface EvaluationListRow {
+  id: string;
+  evaluationNo: string;
+  status: EvaluationStatus;
+  workStatus: WorkStatus | null;
+  priority: CompanyPriority | 0;
+  title: string;
+  company: string;
+  branch: string;
+  organization: string;
+  category: string;
+  bidType: string | undefined;
+  deadline: string;
+  evaluatedAt: string;
+  prefecture: string;
 }


### PR DESCRIPTION
## Summary

Closes #77

- **types/index.ts**: `AnnouncementStatus`, `BidType`, `FilterState`, `AnnouncementListRow`, `EvaluationApiItem`, `EvaluationListRow` 型を追加
- **useAnnouncementListState.ts**: `any[]` を `AnnouncementListRow[]` に置換（API戻り値・rows state）
- **useBidListState.ts**: `any[]` を `EvaluationApiItem[]` / `EvaluationListRow[]` に置換（API戻り値・rows state・map callback）
- **usePartnerDetail.ts**: `useState<any>(null)` を `useState<PartnerDetail | null>(null)` に置換
- **usePartnerDetail.ts**: `WORK_STATUS_ORDER` に不足していた `on_hold`, `cancelled` を補完

## Changes

| File | Before | After |
|------|--------|-------|
| `useAnnouncementListState.ts` | `any[]` x2 | `AnnouncementListRow[]` |
| `useBidListState.ts` | `any[]` x2, `(e: any)` x1 | `EvaluationApiItem[]`, `EvaluationListRow[]` |
| `usePartnerDetail.ts` | `useState<any>` x1 | `useState<PartnerDetail \| null>` |
| `types/index.ts` | - | 6 new types/interfaces added |

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors
- [ ] Existing functionality unchanged (API calls, DataGrid rendering, filtering)
- [ ] No runtime regressions on list pages and partner detail page

Generated with [Claude Code](https://claude.com/claude-code)