### PR TITLE
refactor(frontend): split detail page components (Issue #90)

### DIFF
--- a/judgesystem/frontend/app/src/pages/OrdererDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/OrdererDetailPage.tsx
@@ -2,746 +2,31 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import {
   Box,
-  Button,
-  Chip,
-  Typography,
-  TextField,
-  InputAdornment,
   Paper,
   Tabs,
   Tab,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  IconButton,
 } from '@mui/material';
-import {
-  Phone as PhoneIcon,
-  Email as EmailIcon,
-  LocationOn as LocationIcon,
-  Print as FaxIcon,
-  CalendarMonth as CalendarIcon,
-  Search as SearchIcon,
-  ExpandMore as ExpandMoreIcon,
-  ArrowBack as ArrowBackIcon,
-  SwapVert as SortIcon,
-  FilterAlt as FilterIcon,
-  Close as CloseIcon,
-} from '@mui/icons-material';
-import { ordererCategoryConfig, announcementStatusConfig, bidTypeConfig } from '../data';
 import { useOrderers } from '../hooks';
-import { categories } from '../constants/categories';
-import { bidTypes } from '../constants/bidType';
 import { prefecturesByRegion } from '../constants/prefectures';
-import type { BidType } from '../types/announcement';
-import { colors, pageStyles, fontSizes, chipStyles, iconStyles, borderRadius, rightPanelColors } from '../constants/styles';
-import type { AnnouncementWithStatus } from '../types';
+import { colors, pageStyles, fontSizes, borderRadius } from '../constants/styles';
 import { useListPageState } from '../hooks';
 import { useSidebar } from '../contexts/SidebarContext';
 import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
-import { CustomPagination } from '../components/bid';
 import { RightSidePanel } from '../components/layout';
 import { getApiUrl } from '../config/api';
-
-
-/**
- * 案件カード（コンパクトグリッド形式）
- */
-function AnnouncementCard({ announcement, onClick }: { announcement: AnnouncementWithStatus; onClick: () => void }) {
-  const statusConfig = announcementStatusConfig[announcement.status];
-  const bidType = announcement.bidType ? bidTypeConfig[announcement.bidType] : null;
-
-  // 都道府県を抽出
-  const prefecture = announcement.workLocation
-    ? announcement.workLocation.match(/^(.+?[都道府県])/)?.[1] || ''
-    : '';
-
-  return (
-    <Box
-      onClick={onClick}
-      sx={{
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
-        p: 2,
-        backgroundColor: colors.text.white,
-        borderRadius: borderRadius.xs,
-        border: `1px solid ${colors.border.main}`,
-        cursor: 'pointer',
-        transition: 'all 0.2s ease',
-        height: '100%',
-        '&:hover': {
-          borderColor: 'rgba(59, 130, 246, 0.4)',
-          boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
-        },
-        '&::before': {
-          content: '""',
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: '3px',
-          backgroundColor: statusConfig.color,
-          borderRadius: `${borderRadius.xs} 0 0 ${borderRadius.xs}`,
-        },
-      }}
-    >
-      {/* 1行目: No. + ステータス + 入札方式 */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-        <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light }}>
-          No. {String(announcement.no).padStart(8, '0')}
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: fontSizes.xs,
-            fontWeight: 600,
-            color: statusConfig.color,
-          }}
-        >
-          {statusConfig.label}
-        </Typography>
-        {bidType && (
-          <>
-            <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
-            <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
-              {bidType.label}
-            </Typography>
-          </>
-        )}
-      </Box>
-
-      {/* 2行目: タイトル */}
-      <Typography
-        sx={{
-          fontWeight: 600,
-          fontSize: fontSizes.md,
-          color: colors.text.secondary,
-          lineHeight: 1.5,
-          mb: 1,
-          flex: 1,
-          display: '-webkit-box',
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          transition: 'color 0.15s',
-          '.MuiBox-root:hover &': {
-            color: colors.primary.main,
-          },
-        }}
-      >
-        {announcement.title}
-      </Typography>
-
-      {/* 3行目: 都道府県・カテゴリ */}
-      <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light, mb: 0.75 }}>
-        {prefecture && `${prefecture}・`}{announcement.category}
-      </Typography>
-
-      {/* 4行目: 公告日・締切日 */}
-      <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
-        公告日 {announcement.publishDate} / 締切日 {announcement.deadline}
-      </Typography>
-    </Box>
-  );
-}
-
-// ソートオプション
-type SortOption = 'deadline_asc' | 'deadline_desc' | 'publish_asc' | 'publish_desc' | 'status_asc' | 'status_desc' | 'prefecture_asc' | 'prefecture_desc';
-
-// ソートフィールド定義
-const SORT_FIELDS = [
-  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
-  { field: 'publish', label: '公告日', ascLabel: '古い', descLabel: '新しい' },
-  { field: 'status', label: 'ステータス', ascLabel: '公開予定→終了', descLabel: '終了→公開予定' },
-  { field: 'prefecture', label: '都道府県', ascLabel: '北→南', descLabel: '南→北' },
-] as const;
-
-// フィルタータブ定義
-const FILTER_TABS = [
-  { id: 'status', label: 'ステータス' },
-  { id: 'bidType', label: '入札方式' },
-  { id: 'category', label: '種別' },
-  { id: 'prefecture', label: '都道府県' },
-] as const;
-
-// ステータスフィルターオプション
-type StatusFilter = AnnouncementWithStatus['status'];
-const STATUS_FILTERS: StatusFilter[] = ['upcoming', 'ongoing', 'awaiting_result', 'closed'];
-
-// フィルター状態の型
-interface AnnouncementFilterState {
-  statuses: StatusFilter[];
-  bidTypes: string[];
-  categories: string[];
-  prefectures: string[];
-}
-
-// 案件用表示条件パネル
-interface AnnouncementConditionsPanelProps {
-  searchQuery: string;
-  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  sortOption: SortOption | null;
-  onSortChange: (option: SortOption | null) => void;
-  filters: AnnouncementFilterState;
-  onFilterChange: (filters: AnnouncementFilterState) => void;
-  onClearAll: () => void;
-  activeTab?: 'sort' | 'filter';
-  onTabChange?: (tab: 'sort' | 'filter') => void;
-}
-
-// フィルターボタン
-function FilterButton({
-  label,
-  selected,
-  onClick,
-  color,
-  bgColor,
-}: {
-  label: string;
-  selected: boolean;
-  onClick: () => void;
-  color?: string;
-  bgColor?: string;
-}) {
-  return (
-    <Box
-      component="button"
-      onClick={onClick}
-      sx={{
-        position: 'relative',
-        padding: '6px 12px',
-        paddingLeft: selected ? '14px' : '12px',
-        borderRadius: borderRadius.xs,
-        fontSize: fontSizes.xs,
-        fontWeight: selected ? 600 : 500,
-        cursor: 'pointer',
-        border: `1px solid ${selected ? (color || colors.accent.blue) : rightPanelColors.inputBorder}`,
-        transition: 'all 0.2s ease',
-        backgroundColor: selected ? bgColor || `${colors.accent.blue}26` : 'transparent',
-        color: selected ? (color || colors.text.white) : rightPanelColors.textMuted,
-        overflow: 'hidden',
-        ...(selected && {
-          '&::before': {
-            content: '""',
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            width: '3px',
-            backgroundColor: color || colors.accent.blue,
-          },
-        }),
-        '&:hover': {
-          backgroundColor: selected ? bgColor || `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-          color: selected ? (color || colors.text.white) : rightPanelColors.text,
-          borderColor: selected ? (color || colors.accent.blue) : `${colors.text.light}99`,
-        },
-      }}
-    >
-      {label}
-    </Box>
-  );
-}
-
-function AnnouncementConditionsPanel({
-  searchQuery,
-  onSearchChange,
-  sortOption,
-  onSortChange,
-  filters,
-  onFilterChange,
-  onClearAll,
-  activeTab,
-  onTabChange,
-}: AnnouncementConditionsPanelProps) {
-  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
-  const [activeFilterTab, setActiveFilterTab] = useState(0);
-  const mainTab = activeTab ?? internalTab;
-  const setMainTab = (tab: 'sort' | 'filter') => {
-    setInternalTab(tab);
-    onTabChange?.(tab);
-  };
-
-  // フィルター件数
-  const filterCounts = {
-    status: filters.statuses.length,
-    bidType: filters.bidTypes.length,
-    category: filters.categories.length,
-    prefecture: filters.prefectures.length,
-  };
-  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
-  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
-
-  // トグル関数
-  const toggleStatus = (status: StatusFilter) => {
-    const newStatuses = filters.statuses.includes(status)
-      ? filters.statuses.filter(s => s !== status)
-      : [...filters.statuses, status];
-    onFilterChange({ ...filters, statuses: newStatuses });
-  };
-
-  const toggleBidType = (bidType: string) => {
-    const newBidTypes = filters.bidTypes.includes(bidType)
-      ? filters.bidTypes.filter(b => b !== bidType)
-      : [...filters.bidTypes, bidType];
-    onFilterChange({ ...filters, bidTypes: newBidTypes });
-  };
-
-  const toggleCategory = (category: string) => {
-    const newCategories = filters.categories.includes(category)
-      ? filters.categories.filter(c => c !== category)
-      : [...filters.categories, category];
-    onFilterChange({ ...filters, categories: newCategories });
-  };
-
-  const togglePrefecture = (pref: string) => {
-    const newPrefs = filters.prefectures.includes(pref)
-      ? filters.prefectures.filter(p => p !== pref)
-      : [...filters.prefectures, pref];
-    onFilterChange({ ...filters, prefectures: newPrefs });
-  };
-
-  // 地域グループ一括トグル（都道府県）
-  const togglePrefRegion = (regionItems: readonly string[]) => {
-    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
-    if (allSelected) {
-      onFilterChange({
-        ...filters,
-        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
-      });
-    } else {
-      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
-      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
-    }
-  };
-
-  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
-    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
-    if (selectedCount === 0) return 'none';
-    if (selectedCount === regionItems.length) return 'all';
-    return 'partial';
-  };
-
-  const sectionDivider = {
-    borderBottom: `1px solid ${rightPanelColors.border}`,
-    pb: 2.5,
-    mb: 2.5,
-  };
-
-  // フィルターコンテンツをレンダリング
-  const renderFilterContent = () => {
-    const tabId = FILTER_TABS[activeFilterTab].id;
-
-    switch (tabId) {
-      case 'status':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {STATUS_FILTERS.map((status) => {
-              const config = announcementStatusConfig[status];
-              return (
-                <FilterButton
-                  key={status}
-                  label={config.label}
-                  selected={filters.statuses.includes(status)}
-                  onClick={() => toggleStatus(status)}
-                  color={config.color}
-                  bgColor={config.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'bidType':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {bidTypes.map((bidType: BidType) => {
-              const config = bidTypeConfig[bidType];
-              return (
-                <FilterButton
-                  key={bidType}
-                  label={config.label}
-                  selected={filters.bidTypes.includes(bidType)}
-                  onClick={() => toggleBidType(bidType)}
-                  color={config.color}
-                  bgColor={config.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'category':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {categories.map((cat) => (
-              <FilterButton
-                key={cat}
-                label={cat}
-                selected={filters.categories.includes(cat)}
-                onClick={() => toggleCategory(cat)}
-              />
-            ))}
-          </Box>
-        );
-
-      case 'prefecture':
-        return (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {prefecturesByRegion.map((region) => {
-              const selectionState = getPrefRegionSelectionState(region.prefectures);
-              return (
-                <Box key={region.region}>
-                  <Box
-                    component="button"
-                    onClick={() => togglePrefRegion(region.prefectures)}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      mb: 1,
-                      py: 0.5,
-                      px: 1,
-                      fontSize: fontSizes.sm,
-                      fontWeight: 600,
-                      cursor: 'pointer',
-                      border: 'none',
-                      borderRadius: borderRadius.xs,
-                      backgroundColor: selectionState !== 'none' ? `${colors.accent.blue}33` : 'transparent',
-                      color: selectionState !== 'none' ? colors.accent.blue : rightPanelColors.text,
-                      '&:hover': { backgroundColor: `${colors.accent.blue}26` },
-                    }}
-                  >
-                    {region.region}
-                    {selectionState === 'partial' && (
-                      <Box
-                        component="span"
-                        sx={{
-                          fontSize: fontSizes.xs,
-                          color: colors.accent.blue,
-                          opacity: 0.8,
-                        }}
-                      >
-                        (一部)
-                      </Box>
-                    )}
-                  </Box>
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                    {region.prefectures.map((pref) => (
-                      <FilterButton
-                        key={pref}
-                        label={pref}
-                        selected={filters.prefectures.includes(pref)}
-                        onClick={() => togglePrefecture(pref)}
-                      />
-                    ))}
-                  </Box>
-                </Box>
-              );
-            })}
-          </Box>
-        );
-
-      default:
-        return null;
-    }
-  };
-
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      {/* クリアボタン */}
-      <Box sx={sectionDivider}>
-        <Button
-          onClick={onClearAll}
-          variant="outlined"
-          size="small"
-          fullWidth
-          disabled={!hasConditions}
-          sx={{
-            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
-            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
-            fontSize: fontSizes.xs,
-            py: 0.75,
-            '&:hover': {
-              borderColor: colors.accent.red,
-              backgroundColor: `${colors.accent.red}1a`,
-            },
-            '&.Mui-disabled': {
-              color: rightPanelColors.textMuted,
-              borderColor: rightPanelColors.inputBorder,
-            },
-          }}
-        >
-          すべてクリア
-        </Button>
-      </Box>
-
-      {/* 検索 */}
-      <Box sx={sectionDivider}>
-        <TextField
-          placeholder="検索..."
-          value={searchQuery}
-          onChange={onSearchChange}
-          size="small"
-          fullWidth
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              fontSize: fontSizes.sm,
-              color: rightPanelColors.text,
-              backgroundColor: rightPanelColors.inputBg,
-              '& fieldset': { borderColor: rightPanelColors.inputBorder },
-              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
-              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
-            },
-            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
-              </InputAdornment>
-            ),
-            endAdornment: searchQuery && (
-              <InputAdornment position="end">
-                <IconButton
-                  size="small"
-                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
-                  sx={{ color: rightPanelColors.textMuted }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Box>
-
-      {/* ソート/フィルター タブ */}
-      <Box>
-        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
-          <Box
-            onClick={() => setMainTab('sort')}
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 0.75,
-              py: 1.25,
-              cursor: 'pointer',
-              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
-              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
-              fontWeight: 600,
-              fontSize: fontSizes.sm,
-            }}
-          >
-            <SortIcon sx={iconStyles.medium} />
-            ソート
-          </Box>
-          <Box
-            onClick={() => setMainTab('filter')}
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 0.75,
-              py: 1.25,
-              cursor: 'pointer',
-              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
-              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
-              fontWeight: 600,
-              fontSize: fontSizes.sm,
-            }}
-          >
-            <FilterIcon sx={iconStyles.medium} />
-            フィルター
-            {totalFilterCount > 0 && (
-              <Box
-                component="span"
-                sx={{
-                  padding: '2px 6px',
-                  borderRadius: borderRadius.xs,
-                  fontSize: fontSizes.xs,
-                  fontWeight: 600,
-                  backgroundColor: `${colors.accent.blue}4d`,
-                  color: colors.accent.blue,
-                }}
-              >
-                {totalFilterCount}
-              </Box>
-            )}
-          </Box>
-        </Box>
-
-        {/* ソートコンテンツ */}
-        {mainTab === 'sort' && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
-              const ascOption = `${field}_asc` as SortOption;
-              const descOption = `${field}_desc` as SortOption;
-              const isAsc = sortOption === ascOption;
-              const isDesc = sortOption === descOption;
-              const isActive = isAsc || isDesc;
-              const buttonText = !isActive
-                ? label
-                : isAsc
-                  ? `${label}：${ascLabel}↑`
-                  : `${label}：${descLabel}↓`;
-
-              return (
-                <Box
-                  component="button"
-                  key={field}
-                  onClick={() => {
-                    if (!isActive) {
-                      onSortChange(ascOption);
-                    } else if (isAsc) {
-                      onSortChange(descOption);
-                    } else {
-                      onSortChange(null); // 選択解除
-                    }
-                  }}
-                  sx={{
-                    position: 'relative',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'flex-start',
-                    width: '100%',
-                    px: 2,
-                    pl: isActive ? 2.5 : 2,
-                    py: 1.5,
-                    fontSize: fontSizes.md,
-                    fontWeight: isActive ? 600 : 500,
-                    borderRadius: borderRadius.xs,
-                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
-                    cursor: 'pointer',
-                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
-                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
-                    ...(isActive && {
-                      '&::before': {
-                        content: '""',
-                        position: 'absolute',
-                        left: 0,
-                        top: 0,
-                        bottom: 0,
-                        width: '3px',
-                        backgroundColor: colors.accent.blue,
-                      },
-                    }),
-                    '&:hover': {
-                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-                      color: isActive ? colors.text.white : rightPanelColors.text,
-                    },
-                  }}
-                >
-                  {buttonText}
-                </Box>
-              );
-            })}
-          </Box>
-        )}
-
-        {/* フィルターコンテンツ */}
-        {mainTab === 'filter' && (
-          <Box>
-            {/* カテゴリ選択ボタン（グリッド） */}
-            <Box sx={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 0.75,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${rightPanelColors.border}`
-            }}>
-              {FILTER_TABS.map((tab, index) => {
-                const count = filterCounts[tab.id as keyof typeof filterCounts];
-                const isActive = activeFilterTab === index;
-                return (
-                  <Box
-                    component="button"
-                    key={tab.id}
-                    onClick={() => setActiveFilterTab(index)}
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      px: 1,
-                      py: 1.25,
-                      fontSize: fontSizes.sm,
-                      fontWeight: isActive ? 600 : 500,
-                      borderRadius: borderRadius.xs,
-                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
-                      cursor: 'pointer',
-                      position: 'relative',
-                      overflow: 'hidden',
-                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
-                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
-                      ...(isActive && {
-                        '&::before': {
-                          content: '""',
-                          position: 'absolute',
-                          left: 0,
-                          top: 0,
-                          bottom: 0,
-                          width: '3px',
-                          backgroundColor: colors.accent.blue,
-                        },
-                      }),
-                      '&:hover': {
-                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-                        color: isActive ? colors.text.white : rightPanelColors.text,
-                      },
-                    }}
-                  >
-                    {tab.label}
-                    {count > 0 && (
-                      <Box
-                        component="span"
-                        sx={{
-                          position: 'absolute',
-                          top: 4,
-                          right: 4,
-                          padding: '1px 5px',
-                          borderRadius: borderRadius.xs,
-                          fontSize: fontSizes.xs,
-                          fontWeight: 700,
-                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
-                          color: colors.text.white,
-                          minWidth: 14,
-                          textAlign: 'center',
-                        }}
-                      >
-                        {count}
-                      </Box>
-                    )}
-                  </Box>
-                );
-              })}
-            </Box>
-
-            {/* フィルター詳細コンテンツ */}
-            <Box sx={{ minHeight: 100 }}>
-              {renderFilterContent()}
-            </Box>
-          </Box>
-        )}
-      </Box>
-    </Box>
-  );
-}
-
-// ステータスの順序（ソート用）
-const STATUS_ORDER: Record<StatusFilter, number> = {
-  upcoming: 0,
-  ongoing: 1,
-  awaiting_result: 2,
-  closed: 3,
-};
-
-// ナビゲーション追跡用
-const NAV_TRACKING_KEY = 'lastVisitedPath';
+import {
+  OrdererDetailHeader,
+  OrdererInfoTab,
+  OrdererAnnouncementsTab,
+  AnnouncementConditionsPanel,
+} from './orderer-detail';
+import type {
+  SortOption,
+  StatusFilter,
+  AnnouncementFilterState,
+} from './orderer-detail';
+import { STATUS_ORDER, NAV_TRACKING_KEY } from './orderer-detail';
+import type { AnnouncementWithStatus } from '../types';
 
 export default function OrdererDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -752,14 +37,14 @@ export default function OrdererDetailPage() {
   const { orderers } = useOrderers();
   const [conditionTab, setConditionTab] = useState<'sort' | 'filter'>('sort');
 
-  // 詳細ページのパスを保存（一覧に戻った時のページ復元用）
+  // Save detail page path for page restoration when returning to list
   useEffect(() => {
     try {
       sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname);
     } catch { /* ignore */ }
   }, [location.pathname]);
 
-  // ソート・フィルター状態
+  // Sort & filter state
   const [sortOption, setSortOption] = useState<SortOption | null>(null);
   const [filters, setFilters] = useState<AnnouncementFilterState>({
     statuses: [],
@@ -768,7 +53,7 @@ export default function OrdererDetailPage() {
     prefectures: [],
   });
 
-  // サイドパネル制御
+  // Side panel control
   const handleOpenWithTab = useCallback((tab: 'sort' | 'filter') => {
     setConditionTab(tab);
     if (!rightPanelOpen) {
@@ -778,7 +63,7 @@ export default function OrdererDetailPage() {
 
   const orderer = orderers.find((o) => o.id === id);
 
-  // この発注者の案件をAPIから取得
+  // Fetch announcements for this orderer from API
   const [ordererAnnouncements, setOrdererAnnouncements] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -814,7 +99,7 @@ export default function OrdererDetailPage() {
     searchFields: ['title', 'category', 'workLocation'],
   });
 
-  // 都道府県の順序（北→南）
+  // Prefecture ordering (north to south)
   const PREFECTURE_ORDER: Record<string, number> = useMemo(() => {
     const order: Record<string, number> = {};
     let idx = 0;
@@ -826,29 +111,24 @@ export default function OrdererDetailPage() {
     return order;
   }, []);
 
-  // 都道府県を抽出するヘルパー関数
+  // Extract prefecture from work location
   const extractPrefecture = (workLocation: string): string => {
     const match = workLocation?.match(/^(.+?[都道府県])/);
     return match ? match[1] : '';
   };
 
-  // フィルターとソートを適用
+  // Apply filters and sort
   const announcementRows = useMemo(() => {
-    // フィルター適用
     let filtered = baseRows.filter((row) => {
-      // ステータスフィルター
       if (filters.statuses.length > 0 && !filters.statuses.includes(row.status as StatusFilter)) {
         return false;
       }
-      // 入札形式フィルター
       if (filters.bidTypes.length > 0 && (!row.bidType || !filters.bidTypes.includes(row.bidType))) {
         return false;
       }
-      // カテゴリフィルター
       if (filters.categories.length > 0 && !filters.categories.includes(row.category)) {
         return false;
       }
-      // 都道府県フィルター
       if (filters.prefectures.length > 0) {
         const pref = extractPrefecture(row.workLocation);
         if (!pref || !filters.prefectures.includes(pref)) {
@@ -858,7 +138,6 @@ export default function OrdererDetailPage() {
       return true;
     });
 
-    // ソート適用（nullの場合は元の順序を維持）
     if (!sortOption) {
       return filtered;
     }
@@ -907,61 +186,19 @@ export default function OrdererDetailPage() {
     );
   }
 
-  const categoryConfig = ordererCategoryConfig[orderer.category];
-
   return (
     <Box sx={{ height: '100vh', bgcolor: colors.page.background, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       <Box sx={{ ...pageStyles.contentArea, maxWidth: '100%', py: 3, display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-        {/* ヘッダー */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
-          <Box sx={{ pl: 2, borderLeft: '4px solid', borderColor: categoryConfig.color }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
-              <Button
-                size="small"
-                startIcon={<ArrowBackIcon sx={iconStyles.small} />}
-                onClick={() => navigate('/orderers')}
-                sx={{
-                  color: colors.text.muted,
-                  fontWeight: 500,
-                  fontSize: fontSizes.sm,
-                  textTransform: 'none',
-                  px: 1,
-                  py: 0.25,
-                  minWidth: 'auto',
-                  '&:hover': { backgroundColor: colors.border.light },
-                }}
-              >
-                一覧に戻る
-              </Button>
-              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: categoryConfig.color }}>
-                {categoryConfig.label}
-              </Typography>
-              <Typography sx={{ color: colors.border.dark }}>|</Typography>
-              <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>
-                最終公告: {orderer.lastAnnouncementDate}
-              </Typography>
-            </Box>
-            <Typography sx={pageStyles.detailPageTitle}>
-              {orderer.name}
-            </Typography>
-          </Box>
-          <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 3, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
-              No. {String(orderer.no).padStart(8, '0')}
-            </Typography>
-            <Typography sx={{ fontSize: fontSizes.xl, fontWeight: 700, color: colors.primary.main }}>
-              <Typography component="span" sx={{ fontSize: fontSizes.sm, fontWeight: 500, color: colors.text.muted }}>
-                公告件数{" "}
-              </Typography>
-              {orderer.announcementCount.toLocaleString()}件
-            </Typography>
-          </Box>
-        </Box>
+        {/* Header */}
+        <OrdererDetailHeader
+          orderer={orderer}
+          onBack={() => navigate('/orderers')}
+        />
 
-        {/* メインカード + サイドパネル */}
+        {/* Main card + side panel */}
         <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
           <Paper sx={{ borderRadius: borderRadius.xs, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)', flex: 1, display: 'flex', flexDirection: 'column' }}>
-            {/* タブ */}
+            {/* Tabs */}
             <Box sx={{ borderBottom: `1px solid ${colors.border.main}`, backgroundColor: colors.text.white }}>
               <Tabs
                 value={activeTab}
@@ -977,140 +214,25 @@ export default function OrdererDetailPage() {
               </Tabs>
             </Box>
 
-            {/* タブコンテンツ */}
+            {/* Tab content */}
             <Box sx={{ flex: 1, overflow: 'auto', backgroundColor: colors.background.hover, display: 'flex', flexDirection: 'column' }}>
-              {/* 基本情報タブ */}
               {activeTab === 0 && (
-              <Box sx={{ p: 2.5 }}>
-                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
-                  {/* 左カラム */}
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                    {/* 基本情報 */}
-                    <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
-                        <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>発注者情報</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
-                        <InfoRow label="所在地" value={orderer.address} icon={<LocationIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
-                        <InfoRow label="電話番号" value={orderer.phone} icon={<PhoneIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
-                        <InfoRow label="FAX" value={orderer.fax} icon={<FaxIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
-                        <InfoRow label="メール" value={orderer.email} icon={<EmailIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
-                        <InfoRow label="最終公告日" value={orderer.lastAnnouncementDate} icon={<CalendarIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
-                      </AccordionDetails>
-                    </Accordion>
+                <OrdererInfoTab orderer={orderer} />
+              )}
 
-                  </Box>
-
-                  {/* 右カラム */}
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-                    {/* 統計サマリー */}
-                    <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
-                        <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>統計サマリー</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails sx={{ pt: 2, pb: 2, px: 0, backgroundColor: colors.background.hover }}>
-                        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr auto 1fr', alignItems: 'center' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
-                            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>公告件数</Typography>
-                            <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{orderer.announcementCount.toLocaleString()}件</Typography>
-                          </Box>
-                          <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
-                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
-                            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>落札件数</Typography>
-                            <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{orderer.awardCount.toLocaleString()}件</Typography>
-                          </Box>
-                          <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
-                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
-                            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>平均落札額</Typography>
-                            <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{(orderer.averageAmount / 10000).toLocaleString()}万</Typography>
-                          </Box>
-                        </Box>
-                      </AccordionDetails>
-                    </Accordion>
-
-                    {/* 担当部署 */}
-                    <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
-                      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
-                        <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>担当部署 ({orderer.departments.length})</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
-                        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-                          {orderer.departments.map((dept) => (
-                            <Chip
-                              key={dept}
-                              label={dept}
-                              size="small"
-                              sx={{
-                                ...chipStyles.small,
-                                backgroundColor: colors.status.info.bg,
-                                color: colors.accent.blue,
-                              }}
-                            />
-                          ))}
-                        </Box>
-                      </AccordionDetails>
-                    </Accordion>
-                  </Box>
-                </Box>
-              </Box>
-            )}
-
-            {/* 入札案件タブ */}
-            {activeTab === 1 && (
-              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-                {/* カードグリッド */}
-                <Box sx={{ flex: 1, overflow: 'auto', p: 2, backgroundColor: colors.background.hover }}>
-                  {loading ? (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
-                        読み込み中...
-                      </Typography>
-                    </Box>
-                  ) : announcementRows.length === 0 ? (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
-                        案件が見つかりません
-                      </Typography>
-                    </Box>
-                  ) : (
-                    <Box
-                      sx={{
-                        display: 'grid',
-                        gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-                        gap: 1.5,
-                      }}
-                    >
-                      {announcementRows
-                        .slice(
-                          paginationModel.page * paginationModel.pageSize,
-                          (paginationModel.page + 1) * paginationModel.pageSize
-                        )
-                        .map((announcement) => (
-                          <AnnouncementCard
-                            key={announcement.id}
-                            announcement={announcement as AnnouncementWithStatus}
-                            onClick={() => handleAnnouncementClick(announcement.id)}
-                          />
-                        ))}
-                    </Box>
-                  )}
-                </Box>
-                {/* ページネーション */}
-                <Box sx={{ backgroundColor: colors.text.white, borderTop: `1px solid ${colors.border.main}`, px: 2 }}>
-                  <CustomPagination
-                    page={paginationModel.page}
-                    pageSize={paginationModel.pageSize}
-                    rowCount={announcementRows.length}
-                    onPageChange={(page) => handlePaginationModelChange({ ...paginationModel, page })}
-                    onPageSizeChange={(pageSize) => handlePaginationModelChange({ page: 0, pageSize })}
-                  />
-                </Box>
-              </Box>
-            )}
+              {activeTab === 1 && (
+                <OrdererAnnouncementsTab
+                  loading={loading}
+                  announcements={announcementRows as AnnouncementWithStatus[]}
+                  paginationModel={paginationModel}
+                  onPaginationModelChange={handlePaginationModelChange}
+                  onAnnouncementClick={handleAnnouncementClick}
+                />
+              )}
             </Box>
           </Paper>
 
-          {/* 右サイドパネル（入札案件タブの時のみ表示） */}
+          {/* Right side panel (visible only on announcements tab) */}
           {activeTab === 1 && (
             <RightSidePanel
               open={rightPanelOpen}
@@ -1140,17 +262,6 @@ export default function OrdererDetailPage() {
       </Box>
       <FloatingBackButton onClick={() => navigate('/orderers')} />
       <ScrollToTopButton />
-    </Box>
-  );
-}
-
-// 情報行コンポーネント
-function InfoRow({ label, value, icon }: { label: string; value: string; icon?: React.ReactNode }) {
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1.25, borderBottom: `1px solid ${colors.background.hover}`, '&:last-child': { borderBottom: 'none' } }}>
-      {icon && <Box sx={{ mt: 0.25 }}>{icon}</Box>}
-      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, fontWeight: 500, minWidth: 80 }}>{label}</Typography>
-      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.secondary, fontWeight: 500, flex: 1 }}>{value}</Typography>
     </Box>
   );
 }

--- a/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
+++ b/judgesystem/frontend/app/src/pages/PartnerDetailPage.tsx
@@ -2,809 +2,29 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import {
   Box,
-  Button,
   Typography,
   Paper,
-  TextField,
-  InputAdornment,
   Tabs,
   Tab,
-  IconButton,
 } from '@mui/material';
-import {
-  Search as SearchIcon,
-  ArrowBack as ArrowBackIcon,
-  SwapVert as SortIcon,
-  FilterAlt as FilterIcon,
-  Close as CloseIcon,
-} from '@mui/icons-material';
-import { bidTypeConfig } from '../data';
-import { colors, pageStyles, fontSizes, iconStyles, borderRadius, rightPanelColors } from '../constants/styles';
-import { workStatusConfig } from '../constants/workStatus';
-import { evaluationStatusConfig } from '../constants/status';
-import { priorityLabels, priorityColors } from '../constants/priority';
-import { categories } from '../constants/categories';
-import { bidTypes } from '../constants/bidType';
-import { prefecturesByRegion } from '../constants/prefectures';
-import { organizationGroupsByRegion } from '../constants/organizations';
-import { NotFoundView, FloatingBackButton, ScrollToTopButton, FilterButton } from '../components/common';
+import { colors, pageStyles, fontSizes, borderRadius } from '../constants/styles';
+import { NotFoundView, FloatingBackButton, ScrollToTopButton } from '../components/common';
 import { RightSidePanel } from '../components/layout';
 import { PartnerBasicInfo, PartnerQualifications, PartnerHistory } from '../components/partner';
 import { useSidebar } from '../contexts/SidebarContext';
 import type { PastProject, PartnerDetail } from '../types/partner';
-import type { BidType } from '../types/announcement';
 import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../types';
 import { getApiUrl } from '../config/api';
-
-// ソートオプション
-type SortOption =
-  | 'deadline_asc' | 'deadline_desc'
-  | 'evaluationStatus_asc' | 'evaluationStatus_desc'
-  | 'workStatus_asc' | 'workStatus_desc'
-  | 'priority_asc' | 'priority_desc'
-  | 'prefecture_asc' | 'prefecture_desc'
-  | 'evaluatedAt_asc' | 'evaluatedAt_desc';
-
-// ソートフィールド定義
-const SORT_FIELDS = [
-  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
-  { field: 'evaluationStatus', label: '参加可否', ascLabel: '可能→不可', descLabel: '不可→可能' },
-  { field: 'workStatus', label: '着手状況', ascLabel: '未着手→完了', descLabel: '完了→未着手' },
-  { field: 'priority', label: '優先度', ascLabel: '高→低', descLabel: '低→高' },
-  { field: 'prefecture', label: '都道府県', ascLabel: 'あ→わ', descLabel: 'わ→あ' },
-  { field: 'evaluatedAt', label: '判定日', ascLabel: '古い→新しい', descLabel: '新しい→古い' },
-] as const;
-
-// フィルタータブ定義
-const FILTER_TABS = [
-  { id: 'evaluationStatus', label: '参加可否' },
-  { id: 'priority', label: '優先度' },
-  { id: 'workStatus', label: '着手状況' },
-  { id: 'bidType', label: '入札方式' },
-  { id: 'category', label: '種別' },
-  { id: 'prefecture', label: '都道府県' },
-  { id: 'organization', label: '発注機関' },
-] as const;
-
-// フィルター状態の型
-interface ProjectFilterState {
-  workStatuses: WorkStatus[];
-  evaluationStatuses: EvaluationStatus[];
-  priorities: CompanyPriority[];
-  bidTypes: string[];
-  categories: string[];
-  prefectures: string[];
-  organizations: string[];
-}
-
-// WorkStatus, EvaluationStatus, Priority の配列
-const WORK_STATUS_OPTIONS: WorkStatus[] = ['not_started', 'in_progress', 'completed'];
-const EVALUATION_STATUS_OPTIONS: EvaluationStatus[] = ['all_met', 'other_only_unmet', 'unmet'];
-const PRIORITY_OPTIONS: CompanyPriority[] = [1, 2, 3, 4, 5];
-
-// WorkStatusの順序（ソート用）
-const WORK_STATUS_ORDER: Record<WorkStatus, number> = {
-  not_started: 0,
-  in_progress: 1,
-  completed: 2,
-};
-
-// EvaluationStatusの順序（ソート用：all_met→other_only_unmet→unmet）
-const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
-  all_met: 0,
-  other_only_unmet: 1,
-  unmet: 2,
-};
-
-// 案件用表示条件パネル
-interface ProjectConditionsPanelProps {
-  searchQuery: string;
-  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  sortOption: SortOption | null;
-  onSortChange: (option: SortOption | null) => void;
-  filters: ProjectFilterState;
-  onFilterChange: (filters: ProjectFilterState) => void;
-  onClearAll: () => void;
-  activeTab?: 'sort' | 'filter';
-  onTabChange?: (tab: 'sort' | 'filter') => void;
-  projects: PastProject[];
-}
-
-function ProjectConditionsPanel({
-  searchQuery,
-  onSearchChange,
-  sortOption,
-  onSortChange,
-  filters,
-  onFilterChange,
-  onClearAll,
-  activeTab,
-  onTabChange,
-  projects,
-}: ProjectConditionsPanelProps) {
-  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
-  const [activeFilterTab, setActiveFilterTab] = useState(0);
-  const mainTab = activeTab ?? internalTab;
-  const setMainTab = (tab: 'sort' | 'filter') => {
-    setInternalTab(tab);
-    onTabChange?.(tab);
-  };
-
-  // ステータス件数（元データから計算）
-  const statusCounts = useMemo(() => ({
-    all_met: projects.filter(p => p.evaluationStatus === 'all_met').length,
-    other_only_unmet: projects.filter(p => p.evaluationStatus === 'other_only_unmet').length,
-    unmet: projects.filter(p => p.evaluationStatus === 'unmet').length,
-  }), [projects]);
-
-  // フィルター件数
-  const filterCounts = {
-    workStatus: filters.workStatuses.length,
-    evaluationStatus: filters.evaluationStatuses.length,
-    priority: filters.priorities.length,
-    bidType: filters.bidTypes.length,
-    category: filters.categories.length,
-    prefecture: filters.prefectures.length,
-    organization: filters.organizations.length,
-  };
-  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
-  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
-
-  // トグル関数
-  const toggleWorkStatus = (status: WorkStatus) => {
-    const newStatuses = filters.workStatuses.includes(status)
-      ? filters.workStatuses.filter(s => s !== status)
-      : [...filters.workStatuses, status];
-    onFilterChange({ ...filters, workStatuses: newStatuses });
-  };
-
-  const toggleEvaluationStatus = (status: EvaluationStatus) => {
-    const newStatuses = filters.evaluationStatuses.includes(status)
-      ? filters.evaluationStatuses.filter(s => s !== status)
-      : [...filters.evaluationStatuses, status];
-    onFilterChange({ ...filters, evaluationStatuses: newStatuses });
-  };
-
-  const togglePriority = (priority: CompanyPriority) => {
-    const newPriorities = filters.priorities.includes(priority)
-      ? filters.priorities.filter(p => p !== priority)
-      : [...filters.priorities, priority];
-    onFilterChange({ ...filters, priorities: newPriorities });
-  };
-
-  const toggleBidType = (bidType: string) => {
-    const newBidTypes = filters.bidTypes.includes(bidType)
-      ? filters.bidTypes.filter(b => b !== bidType)
-      : [...filters.bidTypes, bidType];
-    onFilterChange({ ...filters, bidTypes: newBidTypes });
-  };
-
-  const toggleCategory = (category: string) => {
-    const newCategories = filters.categories.includes(category)
-      ? filters.categories.filter(c => c !== category)
-      : [...filters.categories, category];
-    onFilterChange({ ...filters, categories: newCategories });
-  };
-
-  const togglePrefecture = (pref: string) => {
-    const newPrefs = filters.prefectures.includes(pref)
-      ? filters.prefectures.filter(p => p !== pref)
-      : [...filters.prefectures, pref];
-    onFilterChange({ ...filters, prefectures: newPrefs });
-  };
-
-  const togglePrefRegion = (regionItems: readonly string[]) => {
-    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
-    if (allSelected) {
-      onFilterChange({
-        ...filters,
-        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
-      });
-    } else {
-      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
-      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
-    }
-  };
-
-  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
-    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
-    if (selectedCount === 0) return 'none';
-    if (selectedCount === regionItems.length) return 'all';
-    return 'partial';
-  };
-
-  const toggleOrganization = (org: string) => {
-    const newOrgs = filters.organizations.includes(org)
-      ? filters.organizations.filter(o => o !== org)
-      : [...filters.organizations, org];
-    onFilterChange({ ...filters, organizations: newOrgs });
-  };
-
-  const toggleOrgRegion = (regionItems: string[]) => {
-    const allSelected = regionItems.every(item => filters.organizations.includes(item));
-    if (allSelected) {
-      onFilterChange({
-        ...filters,
-        organizations: filters.organizations.filter(o => !regionItems.includes(o)),
-      });
-    } else {
-      const newOrgs = new Set([...filters.organizations, ...regionItems]);
-      onFilterChange({ ...filters, organizations: Array.from(newOrgs) });
-    }
-  };
-
-  const getOrgRegionSelectionState = (regionItems: string[]): 'all' | 'partial' | 'none' => {
-    const selectedCount = regionItems.filter(item => filters.organizations.includes(item)).length;
-    if (selectedCount === 0) return 'none';
-    if (selectedCount === regionItems.length) return 'all';
-    return 'partial';
-  };
-
-  const sectionDivider = {
-    borderBottom: `1px solid ${rightPanelColors.border}`,
-    pb: 2.5,
-    mb: 2.5,
-  };
-
-  // フィルターコンテンツをレンダリング
-  const renderFilterContent = () => {
-    const tabId = FILTER_TABS[activeFilterTab].id;
-
-    switch (tabId) {
-      case 'workStatus':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {WORK_STATUS_OPTIONS.map((status) => {
-              const config = workStatusConfig[status];
-              return (
-                <FilterButton
-                  key={status}
-                  label={config.label}
-                  selected={filters.workStatuses.includes(status)}
-                  onClick={() => toggleWorkStatus(status)}
-                  color={config.color}
-                  bgColor={config.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'evaluationStatus':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {EVALUATION_STATUS_OPTIONS.map((status) => {
-              const config = evaluationStatusConfig[status];
-              return (
-                <FilterButton
-                  key={status}
-                  label={`${config.label} (${statusCounts[status]})`}
-                  selected={filters.evaluationStatuses.includes(status)}
-                  onClick={() => toggleEvaluationStatus(status)}
-                  color={config.color}
-                  bgColor={config.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'priority':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {PRIORITY_OPTIONS.map((priority) => {
-              const pColor = priorityColors[priority];
-              return (
-                <FilterButton
-                  key={priority}
-                  label={priorityLabels[priority]}
-                  selected={filters.priorities.includes(priority)}
-                  onClick={() => togglePriority(priority)}
-                  color={pColor.color}
-                  bgColor={pColor.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'bidType':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {bidTypes.map((bidType: BidType) => {
-              const config = bidTypeConfig[bidType];
-              return (
-                <FilterButton
-                  key={bidType}
-                  label={config.label}
-                  selected={filters.bidTypes.includes(bidType)}
-                  onClick={() => toggleBidType(bidType)}
-                  color={config.color}
-                  bgColor={config.bgColor}
-                />
-              );
-            })}
-          </Box>
-        );
-
-      case 'category':
-        return (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-            {categories.map((cat) => (
-              <FilterButton
-                key={cat}
-                label={cat}
-                selected={filters.categories.includes(cat)}
-                onClick={() => toggleCategory(cat)}
-              />
-            ))}
-          </Box>
-        );
-
-      case 'prefecture':
-        return (
-          <Box>
-            {prefecturesByRegion.map((region) => {
-              const selectionState = getPrefRegionSelectionState(region.prefectures);
-              return (
-                <Box key={region.region} sx={{ mb: 2 }}>
-                  <button
-                    onClick={() => togglePrefRegion(region.prefectures)}
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                      fontSize: fontSizes.xs,
-                      fontWeight: 600,
-                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
-                      marginBottom: '8px',
-                      padding: '4px 10px',
-                      borderRadius: borderRadius.xs,
-                      border: 'none',
-                      cursor: 'pointer',
-                      background:
-                        selectionState === 'all'
-                          ? `${colors.accent.blue}40`
-                          : selectionState === 'partial'
-                            ? `${colors.accent.blue}26`
-                            : 'rgba(255, 255, 255, 0.08)',
-                    }}
-                  >
-                    <span
-                      style={{
-                        width: 14,
-                        height: 14,
-                        borderRadius: '3px',
-                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
-                        background:
-                          selectionState === 'all'
-                            ? colors.accent.blue
-                            : selectionState === 'partial'
-                              ? colors.status.info.light
-                              : 'transparent',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '10px',
-                        color: colors.text.white,
-                      }}
-                    >
-                      {selectionState === 'all' && '✓'}
-                      {selectionState === 'partial' && '−'}
-                    </span>
-                    {region.region}
-                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
-                      ({region.prefectures.filter(item => filters.prefectures.includes(item)).length}/{region.prefectures.length})
-                    </span>
-                  </button>
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-                    {region.prefectures.map((pref) => (
-                      <FilterButton
-                        key={pref}
-                        label={pref}
-                        selected={filters.prefectures.includes(pref)}
-                        onClick={() => togglePrefecture(pref)}
-                      />
-                    ))}
-                  </Box>
-                </Box>
-              );
-            })}
-          </Box>
-        );
-
-      case 'organization':
-        return (
-          <Box>
-            {organizationGroupsByRegion.map((group) => {
-              const selectionState = getOrgRegionSelectionState(group.items);
-              return (
-                <Box key={group.region} sx={{ mb: 2 }}>
-                  <button
-                    onClick={() => toggleOrgRegion(group.items)}
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: '6px',
-                      fontSize: fontSizes.xs,
-                      fontWeight: 600,
-                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
-                      marginBottom: '8px',
-                      padding: '4px 10px',
-                      borderRadius: borderRadius.xs,
-                      border: 'none',
-                      cursor: 'pointer',
-                      background:
-                        selectionState === 'all'
-                          ? `${colors.accent.blue}40`
-                          : selectionState === 'partial'
-                            ? `${colors.accent.blue}26`
-                            : 'rgba(255, 255, 255, 0.08)',
-                    }}
-                  >
-                    <span
-                      style={{
-                        width: 14,
-                        height: 14,
-                        borderRadius: '3px',
-                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
-                        background:
-                          selectionState === 'all'
-                            ? colors.accent.blue
-                            : selectionState === 'partial'
-                              ? colors.status.info.light
-                              : 'transparent',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '10px',
-                        color: colors.text.white,
-                      }}
-                    >
-                      {selectionState === 'all' && '✓'}
-                      {selectionState === 'partial' && '−'}
-                    </span>
-                    {group.region}
-                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
-                      ({group.items.filter(item => filters.organizations.includes(item)).length}/{group.items.length})
-                    </span>
-                  </button>
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
-                    {group.items.map((org) => (
-                      <FilterButton
-                        key={org}
-                        label={org}
-                        selected={filters.organizations.includes(org)}
-                        onClick={() => toggleOrganization(org)}
-                      />
-                    ))}
-                  </Box>
-                </Box>
-              );
-            })}
-          </Box>
-        );
-
-      default:
-        return null;
-    }
-  };
-
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      {/* クリアボタン */}
-      <Box sx={sectionDivider}>
-        <Button
-          onClick={onClearAll}
-          variant="outlined"
-          size="small"
-          fullWidth
-          disabled={!hasConditions}
-          sx={{
-            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
-            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
-            fontSize: fontSizes.xs,
-            py: 0.75,
-            '&:hover': {
-              borderColor: colors.accent.red,
-              backgroundColor: `${colors.accent.red}1a`,
-            },
-            '&.Mui-disabled': {
-              color: rightPanelColors.textMuted,
-              borderColor: rightPanelColors.inputBorder,
-            },
-          }}
-        >
-          すべてクリア
-        </Button>
-      </Box>
-
-      {/* 検索 */}
-      <Box sx={sectionDivider}>
-        <TextField
-          placeholder="検索..."
-          value={searchQuery}
-          onChange={onSearchChange}
-          size="small"
-          fullWidth
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              fontSize: fontSizes.sm,
-              color: rightPanelColors.text,
-              backgroundColor: rightPanelColors.inputBg,
-              '& fieldset': { borderColor: rightPanelColors.inputBorder },
-              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
-              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
-            },
-            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
-              </InputAdornment>
-            ),
-            endAdornment: searchQuery && (
-              <InputAdornment position="end">
-                <IconButton
-                  size="small"
-                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
-                  sx={{ color: rightPanelColors.textMuted }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Box>
-
-      {/* ソート/フィルター タブ */}
-      <Box>
-        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
-          <Box
-            onClick={() => setMainTab('sort')}
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 0.75,
-              py: 1.25,
-              cursor: 'pointer',
-              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
-              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
-              fontWeight: 600,
-              fontSize: fontSizes.sm,
-            }}
-          >
-            <SortIcon sx={iconStyles.medium} />
-            ソート
-          </Box>
-          <Box
-            onClick={() => setMainTab('filter')}
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 0.75,
-              py: 1.25,
-              cursor: 'pointer',
-              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
-              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
-              fontWeight: 600,
-              fontSize: fontSizes.sm,
-            }}
-          >
-            <FilterIcon sx={iconStyles.medium} />
-            フィルター
-            {totalFilterCount > 0 && (
-              <Box
-                component="span"
-                sx={{
-                  padding: '2px 6px',
-                  borderRadius: borderRadius.xs,
-                  fontSize: fontSizes.xs,
-                  fontWeight: 600,
-                  backgroundColor: `${colors.accent.blue}4d`,
-                  color: colors.accent.blue,
-                }}
-              >
-                {totalFilterCount}
-              </Box>
-            )}
-          </Box>
-        </Box>
-
-        {/* ソートコンテンツ */}
-        {mainTab === 'sort' && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
-              const ascOption = `${field}_asc` as SortOption;
-              const descOption = `${field}_desc` as SortOption;
-              const isAsc = sortOption === ascOption;
-              const isDesc = sortOption === descOption;
-              const isActive = isAsc || isDesc;
-              const buttonText = !isActive
-                ? label
-                : isAsc
-                  ? `${label}：${ascLabel}↑`
-                  : `${label}：${descLabel}↓`;
-
-              return (
-                <Box
-                  component="button"
-                  key={field}
-                  onClick={() => {
-                    if (!isActive) {
-                      onSortChange(ascOption);
-                    } else if (isAsc) {
-                      onSortChange(descOption);
-                    } else {
-                      onSortChange(null);
-                    }
-                  }}
-                  sx={{
-                    position: 'relative',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'flex-start',
-                    width: '100%',
-                    px: 2,
-                    pl: isActive ? 2.5 : 2,
-                    py: 1.5,
-                    fontSize: fontSizes.md,
-                    fontWeight: isActive ? 600 : 500,
-                    borderRadius: borderRadius.xs,
-                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
-                    cursor: 'pointer',
-                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
-                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
-                    ...(isActive && {
-                      '&::before': {
-                        content: '""',
-                        position: 'absolute',
-                        left: 0,
-                        top: 0,
-                        bottom: 0,
-                        width: '3px',
-                        backgroundColor: colors.accent.blue,
-                      },
-                    }),
-                    '&:hover': {
-                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-                      color: isActive ? colors.text.white : rightPanelColors.text,
-                    },
-                  }}
-                >
-                  {buttonText}
-                </Box>
-              );
-            })}
-          </Box>
-        )}
-
-        {/* フィルターコンテンツ */}
-        {mainTab === 'filter' && (
-          <Box>
-            {/* カテゴリ選択ボタン（グリッド） */}
-            <Box sx={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 0.75,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${rightPanelColors.border}`
-            }}>
-              {FILTER_TABS.map((tab, index) => {
-                const count = filterCounts[tab.id as keyof typeof filterCounts];
-                const isActive = activeFilterTab === index;
-                const handleDoubleClick = () => {
-                  switch (tab.id) {
-                    case 'evaluationStatus':
-                      onFilterChange({ ...filters, evaluationStatuses: [] });
-                      break;
-                    case 'priority':
-                      onFilterChange({ ...filters, priorities: [] });
-                      break;
-                    case 'workStatus':
-                      onFilterChange({ ...filters, workStatuses: [] });
-                      break;
-                    case 'bidType':
-                      onFilterChange({ ...filters, bidTypes: [] });
-                      break;
-                    case 'category':
-                      onFilterChange({ ...filters, categories: [] });
-                      break;
-                    case 'prefecture':
-                      onFilterChange({ ...filters, prefectures: [] });
-                      break;
-                    case 'organization':
-                      onFilterChange({ ...filters, organizations: [] });
-                      break;
-                  }
-                };
-                return (
-                  <Box
-                    component="button"
-                    key={tab.id}
-                    onClick={() => setActiveFilterTab(index)}
-                    onDoubleClick={handleDoubleClick}
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      px: 1,
-                      py: 1.25,
-                      fontSize: fontSizes.sm,
-                      fontWeight: isActive ? 600 : 500,
-                      borderRadius: borderRadius.xs,
-                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
-                      cursor: 'pointer',
-                      position: 'relative',
-                      overflow: 'hidden',
-                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
-                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
-                      transition: 'all 0.2s ease',
-                      ...(isActive && {
-                        '&::before': {
-                          content: '""',
-                          position: 'absolute',
-                          left: 0,
-                          top: 0,
-                          bottom: 0,
-                          width: '3px',
-                          backgroundColor: colors.accent.blue,
-                        },
-                      }),
-                      '&:hover': {
-                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
-                        color: isActive ? colors.text.white : rightPanelColors.text,
-                        borderColor: isActive ? colors.accent.blue : `${colors.text.light}99`,
-                      },
-                    }}
-                  >
-                    {tab.label}
-                    {count > 0 && (
-                      <Box
-                        component="span"
-                        sx={{
-                          position: 'absolute',
-                          top: 4,
-                          right: 4,
-                          padding: '1px 5px',
-                          borderRadius: borderRadius.xs,
-                          fontSize: fontSizes.xs,
-                          fontWeight: 700,
-                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
-                          color: colors.text.white,
-                          minWidth: 14,
-                          textAlign: 'center',
-                        }}
-                      >
-                        {count}
-                      </Box>
-                    )}
-                  </Box>
-                );
-              })}
-            </Box>
-
-            {/* フィルター詳細コンテンツ */}
-            <Box sx={{ minHeight: 100 }}>
-              {renderFilterContent()}
-            </Box>
-          </Box>
-        )}
-      </Box>
-    </Box>
-  );
-}
-
-// ナビゲーション追跡用
-const NAV_TRACKING_KEY = 'lastVisitedPath';
+import {
+  PartnerDetailHeader,
+  ProjectConditionsPanel,
+} from './partner-detail';
+import type { SortOption, ProjectFilterState } from './partner-detail';
+import {
+  WORK_STATUS_ORDER,
+  EVALUATION_STATUS_ORDER,
+  NAV_TRACKING_KEY,
+} from './partner-detail';
 
 export default function PartnerDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -814,19 +34,19 @@ export default function PartnerDetailPage() {
   const { rightPanelOpen, toggleRightPanel, closeRightPanel, isMobile } = useSidebar();
   const [conditionTab, setConditionTab] = useState<'sort' | 'filter'>('sort');
 
-  // APIからデータ取得
+  // API data fetch
   const [partner, setPartner] = useState<PartnerDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // 詳細ページのパスを保存（一覧に戻った時のページ復元用）
+  // Save detail page path for page restoration when returning to list
   useEffect(() => {
     try {
       sessionStorage.setItem(NAV_TRACKING_KEY, location.pathname);
     } catch { /* ignore */ }
   }, [location.pathname]);
 
-  // パートナー情報をAPIから取得
+  // Fetch partner info from API
   useEffect(() => {
     const fetchPartner = async () => {
       if (!id) return;
@@ -848,12 +68,12 @@ export default function PartnerDetailPage() {
     fetchPartner();
   }, [id]);
 
-  // 対応案件のページネーション・検索状態
+  // Project pagination & search state
   const [projectSearchQuery, setProjectSearchQuery] = useState('');
   const [projectPage, setProjectPage] = useState(0);
   const projectPageSize = 25;
 
-  // ソート・フィルター状態
+  // Sort & filter state
   const [sortOption, setSortOption] = useState<SortOption | null>(null);
   const [filters, setFilters] = useState<ProjectFilterState>({
     workStatuses: [],
@@ -865,7 +85,7 @@ export default function PartnerDetailPage() {
     organizations: [],
   });
 
-  // サイドパネル制御
+  // Side panel control
   const handleOpenWithTab = useCallback((tab: 'sort' | 'filter') => {
     setConditionTab(tab);
     if (!rightPanelOpen) {
@@ -873,13 +93,13 @@ export default function PartnerDetailPage() {
     }
   }, [rightPanelOpen, toggleRightPanel]);
 
-  // 対応案件のフィルタリング
+  // Filter projects
   const filteredProjects = useMemo((): PastProject[] => {
     if (!partner) return [];
     const pastProjects = partner.pastProjects || [];
     if (!Array.isArray(pastProjects)) return [];
 
-    // 検索フィルター
+    // Search filter
     let filtered = pastProjects;
     if (projectSearchQuery) {
       const query = projectSearchQuery.toLowerCase();
@@ -892,7 +112,7 @@ export default function PartnerDetailPage() {
       );
     }
 
-    // フィルター適用
+    // Apply filters
     filtered = filtered.filter((p: PastProject) => {
       if (filters.workStatuses.length > 0 && !filters.workStatuses.includes(p.workStatus)) return false;
       if (filters.evaluationStatuses.length > 0 && !filters.evaluationStatuses.includes(p.evaluationStatus)) return false;
@@ -906,7 +126,7 @@ export default function PartnerDetailPage() {
       return true;
     });
 
-    // ソート適用
+    // Apply sort
     if (!sortOption) return filtered;
 
     return [...filtered].sort((a, b) => {
@@ -953,13 +173,13 @@ export default function PartnerDetailPage() {
     });
   }, [partner, projectSearchQuery, filters, sortOption]);
 
-  // ページネーションされた対応案件
+  // Paginated projects
   const paginatedProjects = useMemo(() => {
     const start = projectPage * projectPageSize;
     return filteredProjects.slice(start, start + projectPageSize);
   }, [filteredProjects, projectPage]);
 
-  // 検索変更ハンドラ
+  // Search change handler
   const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setProjectSearchQuery(e.target.value);
     setProjectPage(0);
@@ -991,7 +211,7 @@ export default function PartnerDetailPage() {
     );
   }
 
-  // データ構造の保証（デフォルト値設定）
+  // Ensure data structure defaults
   const safePartner = {
     ...partner,
     branches: partner.branches || [],
@@ -1003,49 +223,17 @@ export default function PartnerDetailPage() {
   return (
     <Box sx={{ height: '100vh', bgcolor: colors.page.background, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       <Box sx={{ ...pageStyles.contentArea, maxWidth: '100%', py: 3, display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-        {/* ヘッダー */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
-          <Box sx={{ pl: 2, borderLeft: '4px solid', borderColor: colors.accent.blue }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
-              <Button
-                size="small"
-                startIcon={<ArrowBackIcon sx={iconStyles.small} />}
-                onClick={() => navigate('/partners')}
-                sx={{
-                  color: colors.text.muted,
-                  fontWeight: 500,
-                  fontSize: fontSizes.sm,
-                  textTransform: 'none',
-                  px: 1,
-                  py: 0.25,
-                  minWidth: 'auto',
-                  '&:hover': { backgroundColor: colors.border.light },
-                }}
-              >
-                一覧に戻る
-              </Button>
-            </Box>
-            <Typography sx={pageStyles.detailPageTitle}>
-              {safePartner.name}
-            </Typography>
-          </Box>
-          <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 3, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
-              No. {String(safePartner.no).padStart(8, '0')}
-            </Typography>
-            <Typography sx={{ fontSize: fontSizes.xl, fontWeight: 700, color: colors.accent.blue }}>
-              <Typography component="span" sx={{ fontSize: fontSizes.sm, fontWeight: 500, color: colors.text.muted }}>
-                対応案件実績{" "}
-              </Typography>
-              {safePartner.pastProjects.length}件
-            </Typography>
-          </Box>
-        </Box>
+        {/* Header */}
+        <PartnerDetailHeader
+          partner={safePartner}
+          projectCount={safePartner.pastProjects.length}
+          onBack={() => navigate('/partners')}
+        />
 
-        {/* メインカード + サイドパネル */}
+        {/* Main card + side panel */}
         <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
           <Paper sx={{ borderRadius: borderRadius.xs, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)', flex: 1, display: 'flex', flexDirection: 'column' }}>
-            {/* タブ */}
+            {/* Tabs */}
             <Box sx={{ borderBottom: `1px solid ${colors.border.main}`, backgroundColor: colors.text.white }}>
               <Tabs
                 value={activeTab}
@@ -1061,36 +249,31 @@ export default function PartnerDetailPage() {
               </Tabs>
             </Box>
 
-            {/* タブコンテンツ */}
+            {/* Tab content */}
             <Box sx={{ flex: 1, overflow: 'auto', backgroundColor: colors.background.hover, display: 'flex', flexDirection: 'column' }}>
-            {/* 基本情報タブ */}
-            {activeTab === 0 && (
-              <Box sx={{ p: 2.5 }}>
-                <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
-                  {/* 左カラム */}
-                  <PartnerBasicInfo partner={safePartner} />
-
-                  {/* 右カラム */}
-                  <PartnerQualifications partner={safePartner} />
+              {activeTab === 0 && (
+                <Box sx={{ p: 2.5 }}>
+                  <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
+                    <PartnerBasicInfo partner={safePartner} />
+                    <PartnerQualifications partner={safePartner} />
+                  </Box>
                 </Box>
-              </Box>
-            )}
+              )}
 
-            {/* 対応案件タブ */}
-            {activeTab === 1 && (
-              <PartnerHistory
-                projects={paginatedProjects}
-                page={projectPage}
-                pageSize={projectPageSize}
-                filteredCount={filteredProjects.length}
-                onPageChange={setProjectPage}
-                onNavigate={navigate}
-              />
-            )}
+              {activeTab === 1 && (
+                <PartnerHistory
+                  projects={paginatedProjects}
+                  page={projectPage}
+                  pageSize={projectPageSize}
+                  filteredCount={filteredProjects.length}
+                  onPageChange={setProjectPage}
+                  onNavigate={navigate}
+                />
+              )}
             </Box>
           </Paper>
 
-          {/* 右サイドパネル（対応案件タブの時のみ表示） */}
+          {/* Right side panel (visible only on project history tab) */}
           {activeTab === 1 && (
             <RightSidePanel
               open={rightPanelOpen}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/AnnouncementCard.tsx
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/AnnouncementCard.tsx
@@ -1,0 +1,111 @@
+import { Box, Typography } from '@mui/material';
+import { announcementStatusConfig, bidTypeConfig } from '../../data';
+import { colors, fontSizes, borderRadius } from '../../constants/styles';
+import type { AnnouncementWithStatus } from '../../types';
+
+/** Props for the AnnouncementCard component */
+export interface AnnouncementCardProps {
+  announcement: AnnouncementWithStatus;
+  onClick: () => void;
+}
+
+/**
+ * Compact grid-style announcement card.
+ * Displays status, bid type, title, location, and dates.
+ */
+export function AnnouncementCard({ announcement, onClick }: AnnouncementCardProps) {
+  const statusConfig = announcementStatusConfig[announcement.status];
+  const bidType = announcement.bidType ? bidTypeConfig[announcement.bidType] : null;
+
+  const prefecture = announcement.workLocation
+    ? announcement.workLocation.match(/^(.+?[都道府県])/)?.[1] || ''
+    : '';
+
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        p: 2,
+        backgroundColor: colors.text.white,
+        borderRadius: borderRadius.xs,
+        border: `1px solid ${colors.border.main}`,
+        cursor: 'pointer',
+        transition: 'all 0.2s ease',
+        height: '100%',
+        '&:hover': {
+          borderColor: 'rgba(59, 130, 246, 0.4)',
+          boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
+        },
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: '3px',
+          backgroundColor: statusConfig.color,
+          borderRadius: `${borderRadius.xs} 0 0 ${borderRadius.xs}`,
+        },
+      }}
+    >
+      {/* Row 1: No. + status + bid type */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light }}>
+          No. {String(announcement.no).padStart(8, '0')}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: fontSizes.xs,
+            fontWeight: 600,
+            color: statusConfig.color,
+          }}
+        >
+          {statusConfig.label}
+        </Typography>
+        {bidType && (
+          <>
+            <Box sx={{ width: '1px', height: '12px', backgroundColor: colors.border.main }} />
+            <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+              {bidType.label}
+            </Typography>
+          </>
+        )}
+      </Box>
+
+      {/* Row 2: Title */}
+      <Typography
+        sx={{
+          fontWeight: 600,
+          fontSize: fontSizes.md,
+          color: colors.text.secondary,
+          lineHeight: 1.5,
+          mb: 1,
+          flex: 1,
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          transition: 'color 0.15s',
+          '.MuiBox-root:hover &': {
+            color: colors.primary.main,
+          },
+        }}
+      >
+        {announcement.title}
+      </Typography>
+
+      {/* Row 3: Prefecture / category */}
+      <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.light, mb: 0.75 }}>
+        {prefecture && `${prefecture}・`}{announcement.category}
+      </Typography>
+
+      {/* Row 4: Publish date / deadline */}
+      <Typography sx={{ fontSize: fontSizes.xs, color: colors.text.muted }}>
+        公告日 {announcement.publishDate} / 締切日 {announcement.deadline}
+      </Typography>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/AnnouncementConditionsPanel.tsx
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/AnnouncementConditionsPanel.tsx
@@ -1,0 +1,537 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  TextField,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  SwapVert as SortIcon,
+  FilterAlt as FilterIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import { announcementStatusConfig, bidTypeConfig } from '../../data';
+import { categories } from '../../constants/categories';
+import { bidTypes } from '../../constants/bidType';
+import { prefecturesByRegion } from '../../constants/prefectures';
+import type { BidType } from '../../types/announcement';
+import { colors, fontSizes, borderRadius, rightPanelColors, iconStyles } from '../../constants/styles';
+import { FilterButton } from '../../components/common';
+import type {
+  SortOption,
+  StatusFilter,
+  AnnouncementFilterState,
+} from './types';
+import {
+  SORT_FIELDS,
+  FILTER_TABS,
+  STATUS_FILTERS,
+} from './types';
+
+/** Props for AnnouncementConditionsPanel */
+export interface AnnouncementConditionsPanelProps {
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sortOption: SortOption | null;
+  onSortChange: (option: SortOption | null) => void;
+  filters: AnnouncementFilterState;
+  onFilterChange: (filters: AnnouncementFilterState) => void;
+  onClearAll: () => void;
+  activeTab?: 'sort' | 'filter';
+  onTabChange?: (tab: 'sort' | 'filter') => void;
+}
+
+/**
+ * Side panel for controlling search, sort, and filter conditions
+ * on the orderer's announcements list.
+ */
+export function AnnouncementConditionsPanel({
+  searchQuery,
+  onSearchChange,
+  sortOption,
+  onSortChange,
+  filters,
+  onFilterChange,
+  onClearAll,
+  activeTab,
+  onTabChange,
+}: AnnouncementConditionsPanelProps) {
+  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
+  const [activeFilterTab, setActiveFilterTab] = useState(0);
+  const mainTab = activeTab ?? internalTab;
+  const setMainTab = (tab: 'sort' | 'filter') => {
+    setInternalTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // Filter counts
+  const filterCounts = {
+    status: filters.statuses.length,
+    bidType: filters.bidTypes.length,
+    category: filters.categories.length,
+    prefecture: filters.prefectures.length,
+  };
+  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
+  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
+
+  // Toggle functions
+  const toggleStatus = (status: StatusFilter) => {
+    const newStatuses = filters.statuses.includes(status)
+      ? filters.statuses.filter(s => s !== status)
+      : [...filters.statuses, status];
+    onFilterChange({ ...filters, statuses: newStatuses });
+  };
+
+  const toggleBidType = (bidType: string) => {
+    const newBidTypes = filters.bidTypes.includes(bidType)
+      ? filters.bidTypes.filter(b => b !== bidType)
+      : [...filters.bidTypes, bidType];
+    onFilterChange({ ...filters, bidTypes: newBidTypes });
+  };
+
+  const toggleCategory = (category: string) => {
+    const newCategories = filters.categories.includes(category)
+      ? filters.categories.filter(c => c !== category)
+      : [...filters.categories, category];
+    onFilterChange({ ...filters, categories: newCategories });
+  };
+
+  const togglePrefecture = (pref: string) => {
+    const newPrefs = filters.prefectures.includes(pref)
+      ? filters.prefectures.filter(p => p !== pref)
+      : [...filters.prefectures, pref];
+    onFilterChange({ ...filters, prefectures: newPrefs });
+  };
+
+  // Region group toggle (prefectures)
+  const togglePrefRegion = (regionItems: readonly string[]) => {
+    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
+      });
+    } else {
+      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
+      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
+    }
+  };
+
+  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const sectionDivider = {
+    borderBottom: `1px solid ${rightPanelColors.border}`,
+    pb: 2.5,
+    mb: 2.5,
+  };
+
+  // Render filter content by active tab
+  const renderFilterContent = () => {
+    const tabId = FILTER_TABS[activeFilterTab].id;
+
+    switch (tabId) {
+      case 'status':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {STATUS_FILTERS.map((status) => {
+              const config = announcementStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.statuses.includes(status)}
+                  onClick={() => toggleStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'bidType':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {bidTypes.map((bidType: BidType) => {
+              const config = bidTypeConfig[bidType];
+              return (
+                <FilterButton
+                  key={bidType}
+                  label={config.label}
+                  selected={filters.bidTypes.includes(bidType)}
+                  onClick={() => toggleBidType(bidType)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'category':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {categories.map((cat) => (
+              <FilterButton
+                key={cat}
+                label={cat}
+                selected={filters.categories.includes(cat)}
+                onClick={() => toggleCategory(cat)}
+              />
+            ))}
+          </Box>
+        );
+
+      case 'prefecture':
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {prefecturesByRegion.map((region) => {
+              const selectionState = getPrefRegionSelectionState(region.prefectures);
+              return (
+                <Box key={region.region}>
+                  <Box
+                    component="button"
+                    onClick={() => togglePrefRegion(region.prefectures)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      mb: 1,
+                      py: 0.5,
+                      px: 1,
+                      fontSize: fontSizes.sm,
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                      border: 'none',
+                      borderRadius: borderRadius.xs,
+                      backgroundColor: selectionState !== 'none' ? `${colors.accent.blue}33` : 'transparent',
+                      color: selectionState !== 'none' ? colors.accent.blue : rightPanelColors.text,
+                      '&:hover': { backgroundColor: `${colors.accent.blue}26` },
+                    }}
+                  >
+                    {region.region}
+                    {selectionState === 'partial' && (
+                      <Box
+                        component="span"
+                        sx={{
+                          fontSize: fontSizes.xs,
+                          color: colors.accent.blue,
+                          opacity: 0.8,
+                        }}
+                      >
+                        (一部)
+                      </Box>
+                    )}
+                  </Box>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                    {region.prefectures.map((pref) => (
+                      <FilterButton
+                        key={pref}
+                        label={pref}
+                        selected={filters.prefectures.includes(pref)}
+                        onClick={() => togglePrefecture(pref)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Clear button */}
+      <Box sx={sectionDivider}>
+        <Button
+          onClick={onClearAll}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={!hasConditions}
+          sx={{
+            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
+            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
+            fontSize: fontSizes.xs,
+            py: 0.75,
+            '&:hover': {
+              borderColor: colors.accent.red,
+              backgroundColor: `${colors.accent.red}1a`,
+            },
+            '&.Mui-disabled': {
+              color: rightPanelColors.textMuted,
+              borderColor: rightPanelColors.inputBorder,
+            },
+          }}
+        >
+          すべてクリア
+        </Button>
+      </Box>
+
+      {/* Search */}
+      <Box sx={sectionDivider}>
+        <TextField
+          placeholder="検索..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          size="small"
+          fullWidth
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              fontSize: fontSizes.sm,
+              color: rightPanelColors.text,
+              backgroundColor: rightPanelColors.inputBg,
+              '& fieldset': { borderColor: rightPanelColors.inputBorder },
+              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
+              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
+            },
+            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
+                  sx={{ color: rightPanelColors.textMuted }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* Sort / Filter tabs */}
+      <Box>
+        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
+          <Box
+            onClick={() => setMainTab('sort')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <SortIcon sx={iconStyles.medium} />
+            ソート
+          </Box>
+          <Box
+            onClick={() => setMainTab('filter')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <FilterIcon sx={iconStyles.medium} />
+            フィルター
+            {totalFilterCount > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  padding: '2px 6px',
+                  borderRadius: borderRadius.xs,
+                  fontSize: fontSizes.xs,
+                  fontWeight: 600,
+                  backgroundColor: `${colors.accent.blue}4d`,
+                  color: colors.accent.blue,
+                }}
+              >
+                {totalFilterCount}
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* Sort content */}
+        {mainTab === 'sort' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
+              const ascOption = `${field}_asc` as SortOption;
+              const descOption = `${field}_desc` as SortOption;
+              const isAsc = sortOption === ascOption;
+              const isDesc = sortOption === descOption;
+              const isActive = isAsc || isDesc;
+              const buttonText = !isActive
+                ? label
+                : isAsc
+                  ? `${label}：${ascLabel}↑`
+                  : `${label}：${descLabel}↓`;
+
+              return (
+                <Box
+                  component="button"
+                  key={field}
+                  onClick={() => {
+                    if (!isActive) {
+                      onSortChange(ascOption);
+                    } else if (isAsc) {
+                      onSortChange(descOption);
+                    } else {
+                      onSortChange(null);
+                    }
+                  }}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    width: '100%',
+                    px: 2,
+                    pl: isActive ? 2.5 : 2,
+                    py: 1.5,
+                    fontSize: fontSizes.md,
+                    fontWeight: isActive ? 600 : 500,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                    cursor: 'pointer',
+                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                    ...(isActive && {
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '3px',
+                        backgroundColor: colors.accent.blue,
+                      },
+                    }),
+                    '&:hover': {
+                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                      color: isActive ? colors.text.white : rightPanelColors.text,
+                    },
+                  }}
+                >
+                  {buttonText}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* Filter content */}
+        {mainTab === 'filter' && (
+          <Box>
+            {/* Category selection buttons (grid) */}
+            <Box sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 0.75,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${rightPanelColors.border}`
+            }}>
+              {FILTER_TABS.map((tab, index) => {
+                const count = filterCounts[tab.id as keyof typeof filterCounts];
+                const isActive = activeFilterTab === index;
+                return (
+                  <Box
+                    component="button"
+                    key={tab.id}
+                    onClick={() => setActiveFilterTab(index)}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 1.25,
+                      fontSize: fontSizes.sm,
+                      fontWeight: isActive ? 600 : 500,
+                      borderRadius: borderRadius.xs,
+                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                      cursor: 'pointer',
+                      position: 'relative',
+                      overflow: 'hidden',
+                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                      ...(isActive && {
+                        '&::before': {
+                          content: '""',
+                          position: 'absolute',
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: '3px',
+                          backgroundColor: colors.accent.blue,
+                        },
+                      }),
+                      '&:hover': {
+                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                        color: isActive ? colors.text.white : rightPanelColors.text,
+                      },
+                    }}
+                  >
+                    {tab.label}
+                    {count > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          padding: '1px 5px',
+                          borderRadius: borderRadius.xs,
+                          fontSize: fontSizes.xs,
+                          fontWeight: 700,
+                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
+                          color: colors.text.white,
+                          minWidth: 14,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {count}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* Filter detail content */}
+            <Box sx={{ minHeight: 100 }}>
+              {renderFilterContent()}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/OrdererAnnouncementsTab.tsx
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/OrdererAnnouncementsTab.tsx
@@ -1,0 +1,78 @@
+import { Box, Typography } from '@mui/material';
+import { colors, fontSizes, borderRadius } from '../../constants/styles';
+import { CustomPagination } from '../../components/bid';
+import { AnnouncementCard } from './AnnouncementCard';
+import type { AnnouncementWithStatus } from '../../types';
+
+/** Props for OrdererAnnouncementsTab */
+export interface OrdererAnnouncementsTabProps {
+  loading: boolean;
+  announcements: AnnouncementWithStatus[];
+  paginationModel: { page: number; pageSize: number };
+  onPaginationModelChange: (model: { page: number; pageSize: number }) => void;
+  onAnnouncementClick: (id: string) => void;
+}
+
+/**
+ * Announcements tab for the orderer detail page.
+ * Shows a card grid of announcements with pagination.
+ */
+export function OrdererAnnouncementsTab({
+  loading,
+  announcements,
+  paginationModel,
+  onPaginationModelChange,
+  onAnnouncementClick,
+}: OrdererAnnouncementsTabProps) {
+  return (
+    <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+      {/* Card grid */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2, backgroundColor: colors.background.hover }}>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+              読み込み中...
+            </Typography>
+          </Box>
+        ) : announcements.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+              案件が見つかりません
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+              gap: 1.5,
+            }}
+          >
+            {announcements
+              .slice(
+                paginationModel.page * paginationModel.pageSize,
+                (paginationModel.page + 1) * paginationModel.pageSize
+              )
+              .map((announcement) => (
+                <AnnouncementCard
+                  key={announcement.id}
+                  announcement={announcement}
+                  onClick={() => onAnnouncementClick(announcement.id)}
+                />
+              ))}
+          </Box>
+        )}
+      </Box>
+      {/* Pagination */}
+      <Box sx={{ backgroundColor: colors.text.white, borderTop: `1px solid ${colors.border.main}`, px: 2 }}>
+        <CustomPagination
+          page={paginationModel.page}
+          pageSize={paginationModel.pageSize}
+          rowCount={announcements.length}
+          onPageChange={(page) => onPaginationModelChange({ ...paginationModel, page })}
+          onPageSizeChange={(pageSize) => onPaginationModelChange({ page: 0, pageSize })}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/OrdererDetailHeader.tsx
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/OrdererDetailHeader.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, Typography } from '@mui/material';
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { ordererCategoryConfig } from '../../data';
+import { colors, pageStyles, fontSizes, iconStyles } from '../../constants/styles';
+import type { Orderer } from '../../types/orderer';
+
+/** Props for OrdererDetailHeader */
+export interface OrdererDetailHeaderProps {
+  orderer: Orderer;
+  onBack: () => void;
+}
+
+/**
+ * Header section for the orderer detail page.
+ * Displays category, name, last announcement date, and count.
+ */
+export function OrdererDetailHeader({ orderer, onBack }: OrdererDetailHeaderProps) {
+  const categoryConfig = ordererCategoryConfig[orderer.category];
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
+      <Box sx={{ pl: 2, borderLeft: '4px solid', borderColor: categoryConfig.color }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
+          <Button
+            size="small"
+            startIcon={<ArrowBackIcon sx={iconStyles.small} />}
+            onClick={onBack}
+            sx={{
+              color: colors.text.muted,
+              fontWeight: 500,
+              fontSize: fontSizes.sm,
+              textTransform: 'none',
+              px: 1,
+              py: 0.25,
+              minWidth: 'auto',
+              '&:hover': { backgroundColor: colors.border.light },
+            }}
+          >
+            一覧に戻る
+          </Button>
+          <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: categoryConfig.color }}>
+            {categoryConfig.label}
+          </Typography>
+          <Typography sx={{ color: colors.border.dark }}>|</Typography>
+          <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>
+            最終公告: {orderer.lastAnnouncementDate}
+          </Typography>
+        </Box>
+        <Typography sx={pageStyles.detailPageTitle}>
+          {orderer.name}
+        </Typography>
+      </Box>
+      <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 3, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+          No. {String(orderer.no).padStart(8, '0')}
+        </Typography>
+        <Typography sx={{ fontSize: fontSizes.xl, fontWeight: 700, color: colors.primary.main }}>
+          <Typography component="span" sx={{ fontSize: fontSizes.sm, fontWeight: 500, color: colors.text.muted }}>
+            公告件数{" "}
+          </Typography>
+          {orderer.announcementCount.toLocaleString()}件
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/OrdererInfoTab.tsx
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/OrdererInfoTab.tsx
@@ -1,0 +1,114 @@
+import {
+  Box,
+  Chip,
+  Typography,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material';
+import {
+  Phone as PhoneIcon,
+  Email as EmailIcon,
+  LocationOn as LocationIcon,
+  Print as FaxIcon,
+  CalendarMonth as CalendarIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material';
+import { colors, fontSizes, chipStyles, iconStyles, borderRadius } from '../../constants/styles';
+import type { Orderer } from '../../types/orderer';
+
+/** Props for OrdererInfoTab */
+export interface OrdererInfoTabProps {
+  orderer: Orderer;
+}
+
+/** Local info row for orderer detail display */
+function OrdererInfoRow({ label, value, icon }: { label: string; value: string; icon?: React.ReactNode }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2, py: 1.25, borderBottom: `1px solid ${colors.background.hover}`, '&:last-child': { borderBottom: 'none' } }}>
+      {icon && <Box sx={{ mt: 0.25 }}>{icon}</Box>}
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted, fontWeight: 500, minWidth: 80 }}>{label}</Typography>
+      <Typography sx={{ fontSize: fontSizes.md, color: colors.text.secondary, fontWeight: 500, flex: 1 }}>{value}</Typography>
+    </Box>
+  );
+}
+
+/**
+ * Basic information tab for the orderer detail page.
+ * Shows orderer info, statistics summary, and departments.
+ */
+export function OrdererInfoTab({ orderer }: OrdererInfoTabProps) {
+  return (
+    <Box sx={{ p: 2.5 }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2.5 }}>
+        {/* Left column */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {/* Basic info */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>発注者情報</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              <OrdererInfoRow label="所在地" value={orderer.address} icon={<LocationIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <OrdererInfoRow label="電話番号" value={orderer.phone} icon={<PhoneIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <OrdererInfoRow label="FAX" value={orderer.fax} icon={<FaxIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <OrdererInfoRow label="メール" value={orderer.email} icon={<EmailIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+              <OrdererInfoRow label="最終公告日" value={orderer.lastAnnouncementDate} icon={<CalendarIcon sx={{ ...iconStyles.small, color: colors.text.light }} />} />
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+
+        {/* Right column */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {/* Statistics summary */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>統計サマリー</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 0, backgroundColor: colors.background.hover }}>
+              <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr auto 1fr', alignItems: 'center' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+                  <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>公告件数</Typography>
+                  <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{orderer.announcementCount.toLocaleString()}件</Typography>
+                </Box>
+                <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+                  <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>落札件数</Typography>
+                  <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{orderer.awardCount.toLocaleString()}件</Typography>
+                </Box>
+                <Typography sx={{ color: colors.border.dark, px: 1 }}>|</Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1 }}>
+                  <Typography sx={{ fontSize: fontSizes.md, color: colors.text.muted }}>平均落札額</Typography>
+                  <Typography sx={{ fontSize: fontSizes.base, fontWeight: 700, color: colors.text.secondary }}>{(orderer.averageAmount / 10000).toLocaleString()}万</Typography>
+                </Box>
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+
+          {/* Departments */}
+          <Accordion defaultExpanded sx={{ boxShadow: 'none', border: `1px solid ${colors.border.main}`, borderRadius: `${borderRadius.xs} !important`, '&:before': { display: 'none' }, '&.Mui-expanded': { margin: 0 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 48, borderBottom: `1px solid ${colors.border.main}`, '&.Mui-expanded': { minHeight: 48 } }}>
+              <Typography sx={{ fontSize: fontSizes.base, fontWeight: 600, color: colors.primary.main }}>担当部署 ({orderer.departments.length})</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 2, pb: 2, px: 2.5 }}>
+              <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                {orderer.departments.map((dept) => (
+                  <Chip
+                    key={dept}
+                    label={dept}
+                    size="small"
+                    sx={{
+                      ...chipStyles.small,
+                      backgroundColor: colors.status.info.bg,
+                      color: colors.accent.blue,
+                    }}
+                  />
+                ))}
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/orderer-detail/index.ts
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/index.ts
@@ -1,0 +1,27 @@
+export { AnnouncementCard } from './AnnouncementCard';
+export type { AnnouncementCardProps } from './AnnouncementCard';
+
+export { AnnouncementConditionsPanel } from './AnnouncementConditionsPanel';
+export type { AnnouncementConditionsPanelProps } from './AnnouncementConditionsPanel';
+
+export { OrdererDetailHeader } from './OrdererDetailHeader';
+export type { OrdererDetailHeaderProps } from './OrdererDetailHeader';
+
+export { OrdererInfoTab } from './OrdererInfoTab';
+export type { OrdererInfoTabProps } from './OrdererInfoTab';
+
+export { OrdererAnnouncementsTab } from './OrdererAnnouncementsTab';
+export type { OrdererAnnouncementsTabProps } from './OrdererAnnouncementsTab';
+
+export type {
+  SortOption,
+  StatusFilter,
+  AnnouncementFilterState,
+} from './types';
+export {
+  SORT_FIELDS,
+  FILTER_TABS,
+  STATUS_FILTERS,
+  STATUS_ORDER,
+  NAV_TRACKING_KEY,
+} from './types';

--- a/judgesystem/frontend/app/src/pages/orderer-detail/types.ts
+++ b/judgesystem/frontend/app/src/pages/orderer-detail/types.ts
@@ -1,0 +1,49 @@
+import type { AnnouncementWithStatus } from '../../types';
+
+/** Sort option for announcements list */
+export type SortOption =
+  | 'deadline_asc' | 'deadline_desc'
+  | 'publish_asc' | 'publish_desc'
+  | 'status_asc' | 'status_desc'
+  | 'prefecture_asc' | 'prefecture_desc';
+
+/** Status filter derived from announcement status */
+export type StatusFilter = AnnouncementWithStatus['status'];
+
+/** Filter state for announcements */
+export interface AnnouncementFilterState {
+  statuses: StatusFilter[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+}
+
+/** Sort field definition */
+export const SORT_FIELDS = [
+  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
+  { field: 'publish', label: '公告日', ascLabel: '古い', descLabel: '新しい' },
+  { field: 'status', label: 'ステータス', ascLabel: '公開予定→終了', descLabel: '終了→公開予定' },
+  { field: 'prefecture', label: '都道府県', ascLabel: '北→南', descLabel: '南→北' },
+] as const;
+
+/** Filter tab definition */
+export const FILTER_TABS = [
+  { id: 'status', label: 'ステータス' },
+  { id: 'bidType', label: '入札方式' },
+  { id: 'category', label: '種別' },
+  { id: 'prefecture', label: '都道府県' },
+] as const;
+
+/** Status filter options */
+export const STATUS_FILTERS: StatusFilter[] = ['upcoming', 'ongoing', 'awaiting_result', 'closed'];
+
+/** Status ordering for sort */
+export const STATUS_ORDER: Record<StatusFilter, number> = {
+  upcoming: 0,
+  ongoing: 1,
+  awaiting_result: 2,
+  closed: 3,
+};
+
+/** Session storage key for navigation tracking */
+export const NAV_TRACKING_KEY = 'lastVisitedPath';

--- a/judgesystem/frontend/app/src/pages/partner-detail/PartnerDetailHeader.tsx
+++ b/judgesystem/frontend/app/src/pages/partner-detail/PartnerDetailHeader.tsx
@@ -1,0 +1,57 @@
+import { Box, Button, Typography } from '@mui/material';
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { colors, pageStyles, fontSizes, iconStyles } from '../../constants/styles';
+import type { PartnerDetail } from '../../types/partner';
+
+/** Props for PartnerDetailHeader */
+export interface PartnerDetailHeaderProps {
+  partner: PartnerDetail;
+  projectCount: number;
+  onBack: () => void;
+}
+
+/**
+ * Header section for the partner detail page.
+ * Displays partner name, number, and project count.
+ */
+export function PartnerDetailHeader({ partner, projectCount, onBack }: PartnerDetailHeaderProps) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'stretch', mb: 2 }}>
+      <Box sx={{ pl: 2, borderLeft: '4px solid', borderColor: colors.accent.blue }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 0.5, flexWrap: 'wrap' }}>
+          <Button
+            size="small"
+            startIcon={<ArrowBackIcon sx={iconStyles.small} />}
+            onClick={onBack}
+            sx={{
+              color: colors.text.muted,
+              fontWeight: 500,
+              fontSize: fontSizes.sm,
+              textTransform: 'none',
+              px: 1,
+              py: 0.25,
+              minWidth: 'auto',
+              '&:hover': { backgroundColor: colors.border.light },
+            }}
+          >
+            一覧に戻る
+          </Button>
+        </Box>
+        <Typography sx={pageStyles.detailPageTitle}>
+          {partner.name}
+        </Typography>
+      </Box>
+      <Box sx={{ textAlign: 'right', flexShrink: 0, ml: 3, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        <Typography sx={{ fontSize: fontSizes.md, color: colors.text.light }}>
+          No. {String(partner.no).padStart(8, '0')}
+        </Typography>
+        <Typography sx={{ fontSize: fontSizes.xl, fontWeight: 700, color: colors.accent.blue }}>
+          <Typography component="span" sx={{ fontSize: fontSizes.sm, fontWeight: 500, color: colors.text.muted }}>
+            対応案件実績{" "}
+          </Typography>
+          {projectCount}件
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/partner-detail/ProjectConditionsPanel.tsx
+++ b/judgesystem/frontend/app/src/pages/partner-detail/ProjectConditionsPanel.tsx
@@ -1,0 +1,746 @@
+import { useState, useMemo } from 'react';
+import {
+  Box,
+  Button,
+  TextField,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import {
+  Search as SearchIcon,
+  SwapVert as SortIcon,
+  FilterAlt as FilterIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import { bidTypeConfig } from '../../data';
+import { colors, fontSizes, borderRadius, rightPanelColors, iconStyles } from '../../constants/styles';
+import { workStatusConfig } from '../../constants/workStatus';
+import { evaluationStatusConfig } from '../../constants/status';
+import { priorityLabels, priorityColors } from '../../constants/priority';
+import { categories } from '../../constants/categories';
+import { bidTypes } from '../../constants/bidType';
+import { prefecturesByRegion } from '../../constants/prefectures';
+import { organizationGroupsByRegion } from '../../constants/organizations';
+import { FilterButton } from '../../components/common';
+import type { BidType } from '../../types/announcement';
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../../types';
+import type { PastProject } from '../../types/partner';
+import type { SortOption, ProjectFilterState } from './types';
+import {
+  SORT_FIELDS,
+  FILTER_TABS,
+  WORK_STATUS_OPTIONS,
+  EVALUATION_STATUS_OPTIONS,
+  PRIORITY_OPTIONS,
+} from './types';
+
+/** Props for ProjectConditionsPanel */
+export interface ProjectConditionsPanelProps {
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  sortOption: SortOption | null;
+  onSortChange: (option: SortOption | null) => void;
+  filters: ProjectFilterState;
+  onFilterChange: (filters: ProjectFilterState) => void;
+  onClearAll: () => void;
+  activeTab?: 'sort' | 'filter';
+  onTabChange?: (tab: 'sort' | 'filter') => void;
+  projects: PastProject[];
+}
+
+/**
+ * Side panel for controlling search, sort, and filter conditions
+ * on the partner's project history list.
+ */
+export function ProjectConditionsPanel({
+  searchQuery,
+  onSearchChange,
+  sortOption,
+  onSortChange,
+  filters,
+  onFilterChange,
+  onClearAll,
+  activeTab,
+  onTabChange,
+  projects,
+}: ProjectConditionsPanelProps) {
+  const [internalTab, setInternalTab] = useState<'sort' | 'filter'>('sort');
+  const [activeFilterTab, setActiveFilterTab] = useState(0);
+  const mainTab = activeTab ?? internalTab;
+  const setMainTab = (tab: 'sort' | 'filter') => {
+    setInternalTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // Status counts computed from source data
+  const statusCounts = useMemo(() => ({
+    all_met: projects.filter(p => p.evaluationStatus === 'all_met').length,
+    other_only_unmet: projects.filter(p => p.evaluationStatus === 'other_only_unmet').length,
+    unmet: projects.filter(p => p.evaluationStatus === 'unmet').length,
+  }), [projects]);
+
+  // Filter counts
+  const filterCounts = {
+    workStatus: filters.workStatuses.length,
+    evaluationStatus: filters.evaluationStatuses.length,
+    priority: filters.priorities.length,
+    bidType: filters.bidTypes.length,
+    category: filters.categories.length,
+    prefecture: filters.prefectures.length,
+    organization: filters.organizations.length,
+  };
+  const totalFilterCount = Object.values(filterCounts).reduce((a, b) => a + b, 0);
+  const hasConditions = searchQuery.trim() || sortOption !== null || totalFilterCount > 0;
+
+  // Toggle functions
+  const toggleWorkStatus = (status: WorkStatus) => {
+    const newStatuses = filters.workStatuses.includes(status)
+      ? filters.workStatuses.filter(s => s !== status)
+      : [...filters.workStatuses, status];
+    onFilterChange({ ...filters, workStatuses: newStatuses });
+  };
+
+  const toggleEvaluationStatus = (status: EvaluationStatus) => {
+    const newStatuses = filters.evaluationStatuses.includes(status)
+      ? filters.evaluationStatuses.filter(s => s !== status)
+      : [...filters.evaluationStatuses, status];
+    onFilterChange({ ...filters, evaluationStatuses: newStatuses });
+  };
+
+  const togglePriority = (priority: CompanyPriority) => {
+    const newPriorities = filters.priorities.includes(priority)
+      ? filters.priorities.filter(p => p !== priority)
+      : [...filters.priorities, priority];
+    onFilterChange({ ...filters, priorities: newPriorities });
+  };
+
+  const toggleBidType = (bidType: string) => {
+    const newBidTypes = filters.bidTypes.includes(bidType)
+      ? filters.bidTypes.filter(b => b !== bidType)
+      : [...filters.bidTypes, bidType];
+    onFilterChange({ ...filters, bidTypes: newBidTypes });
+  };
+
+  const toggleCategory = (category: string) => {
+    const newCategories = filters.categories.includes(category)
+      ? filters.categories.filter(c => c !== category)
+      : [...filters.categories, category];
+    onFilterChange({ ...filters, categories: newCategories });
+  };
+
+  const togglePrefecture = (pref: string) => {
+    const newPrefs = filters.prefectures.includes(pref)
+      ? filters.prefectures.filter(p => p !== pref)
+      : [...filters.prefectures, pref];
+    onFilterChange({ ...filters, prefectures: newPrefs });
+  };
+
+  const togglePrefRegion = (regionItems: readonly string[]) => {
+    const allSelected = regionItems.every(item => filters.prefectures.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        prefectures: filters.prefectures.filter(p => !regionItems.includes(p)),
+      });
+    } else {
+      const newPrefs = new Set([...filters.prefectures, ...regionItems]);
+      onFilterChange({ ...filters, prefectures: Array.from(newPrefs) });
+    }
+  };
+
+  const getPrefRegionSelectionState = (regionItems: readonly string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.prefectures.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const toggleOrganization = (org: string) => {
+    const newOrgs = filters.organizations.includes(org)
+      ? filters.organizations.filter(o => o !== org)
+      : [...filters.organizations, org];
+    onFilterChange({ ...filters, organizations: newOrgs });
+  };
+
+  const toggleOrgRegion = (regionItems: string[]) => {
+    const allSelected = regionItems.every(item => filters.organizations.includes(item));
+    if (allSelected) {
+      onFilterChange({
+        ...filters,
+        organizations: filters.organizations.filter(o => !regionItems.includes(o)),
+      });
+    } else {
+      const newOrgs = new Set([...filters.organizations, ...regionItems]);
+      onFilterChange({ ...filters, organizations: Array.from(newOrgs) });
+    }
+  };
+
+  const getOrgRegionSelectionState = (regionItems: string[]): 'all' | 'partial' | 'none' => {
+    const selectedCount = regionItems.filter(item => filters.organizations.includes(item)).length;
+    if (selectedCount === 0) return 'none';
+    if (selectedCount === regionItems.length) return 'all';
+    return 'partial';
+  };
+
+  const sectionDivider = {
+    borderBottom: `1px solid ${rightPanelColors.border}`,
+    pb: 2.5,
+    mb: 2.5,
+  };
+
+  // Render filter content by active tab
+  const renderFilterContent = () => {
+    const tabId = FILTER_TABS[activeFilterTab].id;
+
+    switch (tabId) {
+      case 'workStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {WORK_STATUS_OPTIONS.map((status) => {
+              const config = workStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={config.label}
+                  selected={filters.workStatuses.includes(status)}
+                  onClick={() => toggleWorkStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'evaluationStatus':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {EVALUATION_STATUS_OPTIONS.map((status) => {
+              const config = evaluationStatusConfig[status];
+              return (
+                <FilterButton
+                  key={status}
+                  label={`${config.label} (${statusCounts[status]})`}
+                  selected={filters.evaluationStatuses.includes(status)}
+                  onClick={() => toggleEvaluationStatus(status)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'priority':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {PRIORITY_OPTIONS.map((priority) => {
+              const pColor = priorityColors[priority];
+              return (
+                <FilterButton
+                  key={priority}
+                  label={priorityLabels[priority]}
+                  selected={filters.priorities.includes(priority)}
+                  onClick={() => togglePriority(priority)}
+                  color={pColor.color}
+                  bgColor={pColor.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'bidType':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {bidTypes.map((bidType: BidType) => {
+              const config = bidTypeConfig[bidType];
+              return (
+                <FilterButton
+                  key={bidType}
+                  label={config.label}
+                  selected={filters.bidTypes.includes(bidType)}
+                  onClick={() => toggleBidType(bidType)}
+                  color={config.color}
+                  bgColor={config.bgColor}
+                />
+              );
+            })}
+          </Box>
+        );
+
+      case 'category':
+        return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {categories.map((cat) => (
+              <FilterButton
+                key={cat}
+                label={cat}
+                selected={filters.categories.includes(cat)}
+                onClick={() => toggleCategory(cat)}
+              />
+            ))}
+          </Box>
+        );
+
+      case 'prefecture':
+        return (
+          <Box>
+            {prefecturesByRegion.map((region) => {
+              const selectionState = getPrefRegionSelectionState(region.prefectures);
+              return (
+                <Box key={region.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => togglePrefRegion(region.prefectures)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && String.fromCharCode(10003)}
+                      {selectionState === 'partial' && String.fromCharCode(8722)}
+                    </span>
+                    {region.region}
+                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
+                      ({region.prefectures.filter(item => filters.prefectures.includes(item)).length}/{region.prefectures.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {region.prefectures.map((pref) => (
+                      <FilterButton
+                        key={pref}
+                        label={pref}
+                        selected={filters.prefectures.includes(pref)}
+                        onClick={() => togglePrefecture(pref)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      case 'organization':
+        return (
+          <Box>
+            {organizationGroupsByRegion.map((group) => {
+              const selectionState = getOrgRegionSelectionState(group.items);
+              return (
+                <Box key={group.region} sx={{ mb: 2 }}>
+                  <button
+                    onClick={() => toggleOrgRegion(group.items)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      fontSize: fontSizes.xs,
+                      fontWeight: 600,
+                      color: selectionState === 'none' ? rightPanelColors.textMuted : rightPanelColors.text,
+                      marginBottom: '8px',
+                      padding: '4px 10px',
+                      borderRadius: borderRadius.xs,
+                      border: 'none',
+                      cursor: 'pointer',
+                      background:
+                        selectionState === 'all'
+                          ? `${colors.accent.blue}40`
+                          : selectionState === 'partial'
+                            ? `${colors.accent.blue}26`
+                            : 'rgba(255, 255, 255, 0.08)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: '3px',
+                        border: selectionState === 'none' ? `2px solid ${colors.text.muted}` : 'none',
+                        background:
+                          selectionState === 'all'
+                            ? colors.accent.blue
+                            : selectionState === 'partial'
+                              ? colors.status.info.light
+                              : 'transparent',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: '10px',
+                        color: colors.text.white,
+                      }}
+                    >
+                      {selectionState === 'all' && String.fromCharCode(10003)}
+                      {selectionState === 'partial' && String.fromCharCode(8722)}
+                    </span>
+                    {group.region}
+                    <span style={{ fontSize: fontSizes.xs, color: rightPanelColors.textMuted }}>
+                      ({group.items.filter(item => filters.organizations.includes(item)).length}/{group.items.length})
+                    </span>
+                  </button>
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                    {group.items.map((org) => (
+                      <FilterButton
+                        key={org}
+                        label={org}
+                        selected={filters.organizations.includes(org)}
+                        onClick={() => toggleOrganization(org)}
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Clear button */}
+      <Box sx={sectionDivider}>
+        <Button
+          onClick={onClearAll}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disabled={!hasConditions}
+          sx={{
+            color: hasConditions ? colors.accent.red : rightPanelColors.textMuted,
+            borderColor: hasConditions ? `${colors.accent.red}80` : rightPanelColors.inputBorder,
+            fontSize: fontSizes.xs,
+            py: 0.75,
+            '&:hover': {
+              borderColor: colors.accent.red,
+              backgroundColor: `${colors.accent.red}1a`,
+            },
+            '&.Mui-disabled': {
+              color: rightPanelColors.textMuted,
+              borderColor: rightPanelColors.inputBorder,
+            },
+          }}
+        >
+          すべてクリア
+        </Button>
+      </Box>
+
+      {/* Search */}
+      <Box sx={sectionDivider}>
+        <TextField
+          placeholder="検索..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          size="small"
+          fullWidth
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              fontSize: fontSizes.sm,
+              color: rightPanelColors.text,
+              backgroundColor: rightPanelColors.inputBg,
+              '& fieldset': { borderColor: rightPanelColors.inputBorder },
+              '&:hover fieldset': { borderColor: `${colors.text.light}99` },
+              '&.Mui-focused fieldset': { borderColor: colors.accent.blue },
+            },
+            '& .MuiInputBase-input::placeholder': { color: rightPanelColors.textMuted },
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ ...iconStyles.medium, color: rightPanelColors.textMuted }} />
+              </InputAdornment>
+            ),
+            endAdornment: searchQuery && (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => onSearchChange({ target: { value: '' } } as React.ChangeEvent<HTMLInputElement>)}
+                  sx={{ color: rightPanelColors.textMuted }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+
+      {/* Sort / Filter tabs */}
+      <Box>
+        <Box sx={{ display: 'flex', borderBottom: `1px solid ${rightPanelColors.border}`, mb: 2 }}>
+          <Box
+            onClick={() => setMainTab('sort')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'sort' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'sort' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <SortIcon sx={iconStyles.medium} />
+            ソート
+          </Box>
+          <Box
+            onClick={() => setMainTab('filter')}
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.75,
+              py: 1.25,
+              cursor: 'pointer',
+              borderBottom: mainTab === 'filter' ? `2px solid ${colors.accent.blue}` : '2px solid transparent',
+              color: mainTab === 'filter' ? rightPanelColors.text : rightPanelColors.textMuted,
+              fontWeight: 600,
+              fontSize: fontSizes.sm,
+            }}
+          >
+            <FilterIcon sx={iconStyles.medium} />
+            フィルター
+            {totalFilterCount > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  padding: '2px 6px',
+                  borderRadius: borderRadius.xs,
+                  fontSize: fontSizes.xs,
+                  fontWeight: 600,
+                  backgroundColor: `${colors.accent.blue}4d`,
+                  color: colors.accent.blue,
+                }}
+              >
+                {totalFilterCount}
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* Sort content */}
+        {mainTab === 'sort' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {SORT_FIELDS.map(({ field, label, ascLabel, descLabel }) => {
+              const ascOption = `${field}_asc` as SortOption;
+              const descOption = `${field}_desc` as SortOption;
+              const isAsc = sortOption === ascOption;
+              const isDesc = sortOption === descOption;
+              const isActive = isAsc || isDesc;
+              const buttonText = !isActive
+                ? label
+                : isAsc
+                  ? `${label}：${ascLabel}↑`
+                  : `${label}：${descLabel}↓`;
+
+              return (
+                <Box
+                  component="button"
+                  key={field}
+                  onClick={() => {
+                    if (!isActive) {
+                      onSortChange(ascOption);
+                    } else if (isAsc) {
+                      onSortChange(descOption);
+                    } else {
+                      onSortChange(null);
+                    }
+                  }}
+                  sx={{
+                    position: 'relative',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-start',
+                    width: '100%',
+                    px: 2,
+                    pl: isActive ? 2.5 : 2,
+                    py: 1.5,
+                    fontSize: fontSizes.md,
+                    fontWeight: isActive ? 600 : 500,
+                    borderRadius: borderRadius.xs,
+                    border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                    cursor: 'pointer',
+                    backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                    color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                    ...(isActive && {
+                      '&::before': {
+                        content: '""',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: '3px',
+                        backgroundColor: colors.accent.blue,
+                      },
+                    }),
+                    '&:hover': {
+                      backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                      color: isActive ? colors.text.white : rightPanelColors.text,
+                    },
+                  }}
+                >
+                  {buttonText}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+
+        {/* Filter content */}
+        {mainTab === 'filter' && (
+          <Box>
+            {/* Category selection buttons (grid) */}
+            <Box sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 0.75,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${rightPanelColors.border}`
+            }}>
+              {FILTER_TABS.map((tab, index) => {
+                const count = filterCounts[tab.id as keyof typeof filterCounts];
+                const isActive = activeFilterTab === index;
+                const handleDoubleClick = () => {
+                  switch (tab.id) {
+                    case 'evaluationStatus':
+                      onFilterChange({ ...filters, evaluationStatuses: [] });
+                      break;
+                    case 'priority':
+                      onFilterChange({ ...filters, priorities: [] });
+                      break;
+                    case 'workStatus':
+                      onFilterChange({ ...filters, workStatuses: [] });
+                      break;
+                    case 'bidType':
+                      onFilterChange({ ...filters, bidTypes: [] });
+                      break;
+                    case 'category':
+                      onFilterChange({ ...filters, categories: [] });
+                      break;
+                    case 'prefecture':
+                      onFilterChange({ ...filters, prefectures: [] });
+                      break;
+                    case 'organization':
+                      onFilterChange({ ...filters, organizations: [] });
+                      break;
+                  }
+                };
+                return (
+                  <Box
+                    component="button"
+                    key={tab.id}
+                    onClick={() => setActiveFilterTab(index)}
+                    onDoubleClick={handleDoubleClick}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 1.25,
+                      fontSize: fontSizes.sm,
+                      fontWeight: isActive ? 600 : 500,
+                      borderRadius: borderRadius.xs,
+                      border: `1px solid ${isActive ? colors.accent.blue : rightPanelColors.inputBorder}`,
+                      cursor: 'pointer',
+                      position: 'relative',
+                      overflow: 'hidden',
+                      backgroundColor: isActive ? `${colors.accent.blue}26` : 'transparent',
+                      color: isActive ? colors.text.white : rightPanelColors.textMuted,
+                      transition: 'all 0.2s ease',
+                      ...(isActive && {
+                        '&::before': {
+                          content: '""',
+                          position: 'absolute',
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: '3px',
+                          backgroundColor: colors.accent.blue,
+                        },
+                      }),
+                      '&:hover': {
+                        backgroundColor: isActive ? `${colors.accent.blue}33` : 'rgba(255, 255, 255, 0.06)',
+                        color: isActive ? colors.text.white : rightPanelColors.text,
+                        borderColor: isActive ? colors.accent.blue : `${colors.text.light}99`,
+                      },
+                    }}
+                  >
+                    {tab.label}
+                    {count > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          padding: '1px 5px',
+                          borderRadius: borderRadius.xs,
+                          fontSize: fontSizes.xs,
+                          fontWeight: 700,
+                          backgroundColor: isActive ? 'rgba(255,255,255,0.3)' : `${colors.accent.blue}cc`,
+                          color: colors.text.white,
+                          minWidth: 14,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {count}
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* Filter detail content */}
+            <Box sx={{ minHeight: 100 }}>
+              {renderFilterContent()}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/judgesystem/frontend/app/src/pages/partner-detail/index.ts
+++ b/judgesystem/frontend/app/src/pages/partner-detail/index.ts
@@ -1,0 +1,20 @@
+export { ProjectConditionsPanel } from './ProjectConditionsPanel';
+export type { ProjectConditionsPanelProps } from './ProjectConditionsPanel';
+
+export { PartnerDetailHeader } from './PartnerDetailHeader';
+export type { PartnerDetailHeaderProps } from './PartnerDetailHeader';
+
+export type {
+  SortOption,
+  ProjectFilterState,
+} from './types';
+export {
+  SORT_FIELDS,
+  FILTER_TABS,
+  WORK_STATUS_OPTIONS,
+  EVALUATION_STATUS_OPTIONS,
+  PRIORITY_OPTIONS,
+  WORK_STATUS_ORDER,
+  EVALUATION_STATUS_ORDER,
+  NAV_TRACKING_KEY,
+} from './types';

--- a/judgesystem/frontend/app/src/pages/partner-detail/types.ts
+++ b/judgesystem/frontend/app/src/pages/partner-detail/types.ts
@@ -1,0 +1,64 @@
+import type { EvaluationStatus, WorkStatus, CompanyPriority } from '../../types';
+
+/** Sort option for partner projects list */
+export type SortOption =
+  | 'deadline_asc' | 'deadline_desc'
+  | 'evaluationStatus_asc' | 'evaluationStatus_desc'
+  | 'workStatus_asc' | 'workStatus_desc'
+  | 'priority_asc' | 'priority_desc'
+  | 'prefecture_asc' | 'prefecture_desc'
+  | 'evaluatedAt_asc' | 'evaluatedAt_desc';
+
+/** Filter state for partner projects */
+export interface ProjectFilterState {
+  workStatuses: WorkStatus[];
+  evaluationStatuses: EvaluationStatus[];
+  priorities: CompanyPriority[];
+  bidTypes: string[];
+  categories: string[];
+  prefectures: string[];
+  organizations: string[];
+}
+
+/** Sort field definition */
+export const SORT_FIELDS = [
+  { field: 'deadline', label: '締切', ascLabel: '近い', descLabel: '遠い' },
+  { field: 'evaluationStatus', label: '参加可否', ascLabel: '可能→不可', descLabel: '不可→可能' },
+  { field: 'workStatus', label: '着手状況', ascLabel: '未着手→完了', descLabel: '完了→未着手' },
+  { field: 'priority', label: '優先度', ascLabel: '高→低', descLabel: '低→高' },
+  { field: 'prefecture', label: '都道府県', ascLabel: 'あ→わ', descLabel: 'わ→あ' },
+  { field: 'evaluatedAt', label: '判定日', ascLabel: '古い→新しい', descLabel: '新しい→古い' },
+] as const;
+
+/** Filter tab definition */
+export const FILTER_TABS = [
+  { id: 'evaluationStatus', label: '参加可否' },
+  { id: 'priority', label: '優先度' },
+  { id: 'workStatus', label: '着手状況' },
+  { id: 'bidType', label: '入札方式' },
+  { id: 'category', label: '種別' },
+  { id: 'prefecture', label: '都道府県' },
+  { id: 'organization', label: '発注機関' },
+] as const;
+
+/** Status filter options */
+export const WORK_STATUS_OPTIONS: WorkStatus[] = ['not_started', 'in_progress', 'completed'];
+export const EVALUATION_STATUS_OPTIONS: EvaluationStatus[] = ['all_met', 'other_only_unmet', 'unmet'];
+export const PRIORITY_OPTIONS: CompanyPriority[] = [1, 2, 3, 4, 5];
+
+/** WorkStatus ordering for sort */
+export const WORK_STATUS_ORDER: Record<WorkStatus, number> = {
+  not_started: 0,
+  in_progress: 1,
+  completed: 2,
+};
+
+/** EvaluationStatus ordering for sort (all_met -> other_only_unmet -> unmet) */
+export const EVALUATION_STATUS_ORDER: Record<EvaluationStatus, number> = {
+  all_met: 0,
+  other_only_unmet: 1,
+  unmet: 2,
+};
+
+/** Session storage key for navigation tracking */
+export const NAV_TRACKING_KEY = 'lastVisitedPath';


### PR DESCRIPTION
## Summary

- Split `OrdererDetailPage.tsx` (1,154 lines) into 5 focused sub-components under `pages/orderer-detail/`:
  - `AnnouncementCard` - compact grid-style announcement card
  - `AnnouncementConditionsPanel` - search/sort/filter side panel
  - `OrdererDetailHeader` - header with category, name, stats
  - `OrdererInfoTab` - basic info accordions (details, stats, departments)
  - `OrdererAnnouncementsTab` - announcement card grid with pagination
- Split `PartnerDetailPage.tsx` (1,135 lines) into 2 focused sub-components under `pages/partner-detail/`:
  - `ProjectConditionsPanel` - search/sort/filter side panel for projects
  - `PartnerDetailHeader` - header with name, number, project count
- Each sub-component has explicit Props interfaces and self-contained imports
- Shared types and constants extracted to dedicated `types.ts` files
- Barrel exports via `index.ts` in each subdirectory

## Metrics

| File | Before | After |
|------|--------|-------|
| OrdererDetailPage.tsx | 1,154 lines | 267 lines (parent) |
| PartnerDetailPage.tsx | 1,135 lines | 318 lines (parent) |

## Test plan

- [x] TypeScript strict mode compilation: zero errors
- [ ] Manual verification: orderer detail page renders identically
- [ ] Manual verification: partner detail page renders identically
- [ ] Sort/filter/search functionality works unchanged
- [ ] Tab switching (basic info / announcements) works unchanged

Partial fix for #90

Generated with [Claude Code](https://claude.com/claude-code)