### PR TITLE
fix(judgment-engine): Docker起動修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,8 @@ services:
       PGPASSWORD: postgres
     ports:
       - "8082:8000"
+    volumes:
+      - ../judgesystem/data/master:/app/data/master:ro
 
   judgesystem-collector:
     build:

--- a/judgesystem/judgment-engine/requirements.txt
+++ b/judgesystem/judgment-engine/requirements.txt
@@ -13,3 +13,4 @@ pdfplumber>=0.11.0
 PyMuPDF>=1.24.0
 ftfy>=6.1.0
 requests>=2.31.0
+pytz>=2024.1

--- a/judgesystem/judgment-engine/requirements/grade_item.py
+++ b/judgesystem/judgment-engine/requirements/grade_item.py
@@ -144,7 +144,7 @@ def checkAllMinistryUnified(requiredItems, agencyMap, officeLicenses, constructi
         if len(matchingLicenses) == 0:
             return {
                 "is_ok": False,
-                "reason": fr"業種・等級要件：全省庁統一資格で必要な営業品目({"、".join(requiredItems)})を保有していません"
+                "reason": fr"業種・等級要件：全省庁統一資格で必要な営業品目({'、'.join(requiredItems)})を保有していません"
             }
 
         if requiredGrade:
@@ -224,7 +224,7 @@ def checkSpecificAgency(agency, agencyMap, officeLicenses, constructionMap, requ
         if len(matchingLicenses) == 0:
             return {
                 "is_ok": False,
-                "reason": fr"業種・等級要件：{agency}資格で必要な営業品目({"、".join(requiredItems)})を保有していません"
+                "reason": fr"業種・等級要件：{agency}資格で必要な営業品目({'、'.join(requiredItems)})を保有していません"
             }
 
         if requiredGrade:
@@ -285,7 +285,7 @@ def checkDefault(requiredItems, officeLicenses, constructionMap, agencyMap, requ
         if len(matchingLicenses) == 0:
             return {
                 "is_ok": False,
-                "reason": fr"業種・等級要件：必要な営業品目({"、".join(requiredItems)})を保有していません"
+                "reason": fr"業種・等級要件：必要な営業品目({'、'.join(requiredItems)})を保有していません"
             }
 
         if requiredGrade:
@@ -328,7 +328,7 @@ def checkDefault(requiredItems, officeLicenses, constructionMap, agencyMap, requ
                 continue
 
             if not isinstance(agInfo["agency_area"], str):
-                print(fr"agInfo['agency_area'] not str : {agInfo["agency_area"]}")
+                print(f"agInfo['agency_area'] not str : {agInfo['agency_area']}")
                 agInfo["agency_area"] = str(agInfo["agency_area"])
                 # time.sleep(5)
 
@@ -342,7 +342,7 @@ def checkDefault(requiredItems, officeLicenses, constructionMap, agencyMap, requ
         if len(areaLicenses) == 0:
             return {
                 "is_ok": False,
-                "reason": fr"業種・等級要件：必要な地域({"、".join(requiredAreas)})の登録がありません"
+                "reason": fr"業種・等級要件：必要な地域({'、'.join(requiredAreas)})の登録がありません"
             }
 
     return {


### PR DESCRIPTION
## Summary
- マスターデータディレクトリをDocker volumeマウント（`../judgesystem/data/master:/app/data/master:ro`）
- `pytz` 依存を `requirements.txt` に追加
- `grade_item.py` のPython 3.11 f-string構文エラーを修正

## Test plan
- [x] `docker compose up` で全5サービスが正常起動する
- [x] judgment-engineのログに `Uvicorn running` が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)